### PR TITLE
Update README with ADB commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,28 +33,78 @@ Droidrun Portal includes a WebSocket server for real-time event streaming (notif
 See the [WebSocket Events documentation](docs/websocket-events.md) for setup and usage.
 
 ### 💻 ADB Commands
+
+All commands use the ContentProvider authority `content://com.droidrun.portal/`.
+
+#### Query Commands (Reading Data)
+
 ```bash
-# Get accessibility tree as JSON
-adb shell content query --uri content://com.droidrun.portal/a11y_tree
-
-# Get phone state as JSON
-adb shell content query --uri content://com.droidrun.portal/phone_state
-
-# Get combined state (accessibility tree + phone state) as JSON
-adb shell content query --uri content://com.droidrun.portal/state
-
 # Test connection (ping)
 adb shell content query --uri content://com.droidrun.portal/ping
 
-# Keyboard text input (base64 encoded)
+# Get app version
+adb shell content query --uri content://com.droidrun.portal/version
+
+# Get accessibility tree as JSON (visible elements with overlay indices)
+adb shell content query --uri content://com.droidrun.portal/a11y_tree
+
+# Get full accessibility tree with ALL properties (complete node info)
+adb shell content query --uri content://com.droidrun.portal/a11y_tree_full
+
+# Get full tree without filtering small elements (< 1% visibility)
+adb shell content query --uri 'content://com.droidrun.portal/a11y_tree_full?filter=false'
+
+# Get phone state as JSON (current app, focused element, keyboard visibility)
+adb shell content query --uri content://com.droidrun.portal/phone_state
+
+# Get combined state (accessibility tree + phone state)
+adb shell content query --uri content://com.droidrun.portal/state
+
+# Get full combined state (full tree + phone state + device context)
+adb shell content query --uri content://com.droidrun.portal/state_full
+
+# Get full state without filtering
+adb shell content query --uri 'content://com.droidrun.portal/state_full?filter=false'
+
+# Get list of installed launchable apps
+adb shell content query --uri content://com.droidrun.portal/packages
+```
+
+#### Insert Commands (Actions & Configuration)
+
+```bash
+# Keyboard text input (base64 encoded, clears field first by default)
 adb shell content insert --uri content://com.droidrun.portal/keyboard/input --bind base64_text:s:"SGVsbG8gV29ybGQ="
 
-# Clear text via keyboard
+# Keyboard text input without clearing the field first
+adb shell content insert --uri content://com.droidrun.portal/keyboard/input --bind base64_text:s:"SGVsbG8=" --bind clear:b:false
+
+# Clear text in focused input field
 adb shell content insert --uri content://com.droidrun.portal/keyboard/clear
 
-# Send key event via keyboard (e.g., Enter key = 66)
+# Send key event via keyboard (e.g., Enter key = 66, Backspace = 67)
 adb shell content insert --uri content://com.droidrun.portal/keyboard/key --bind key_code:i:66
+
+# Set overlay vertical offset (in pixels)
+adb shell content insert --uri content://com.droidrun.portal/overlay_offset --bind offset:i:100
+
+# Toggle overlay visibility (show/hide)
+adb shell content insert --uri content://com.droidrun.portal/overlay_visible --bind visible:b:true
+adb shell content insert --uri content://com.droidrun.portal/overlay_visible --bind visible:b:false
+
+# Configure REST API socket server port (default: 8080)
+adb shell content insert --uri content://com.droidrun.portal/socket_port --bind port:i:8090
 ```
+
+#### Common Key Codes
+
+| Key | Code | Key | Code |
+|-----|------|-----|------|
+| Enter | 66 | Backspace | 67 |
+| Tab | 61 | Escape | 111 |
+| Home | 3 | Back | 4 |
+| Up | 19 | Down | 20 |
+| Left | 21 | Right | 22 |
 
 ### 📤 Data Output
 Element data is returned in JSON format through the ContentProvider queries. The response includes a status field and the requested data. All responses follow this structure:


### PR DESCRIPTION
Add comprehensive documentation for all ContentProvider endpoints:
- Query commands: ping, version, a11y_tree, a11y_tree_full, phone_state, state, state_full, packages (with filter parameter examples)
- Insert commands: keyboard input/clear/key, overlay_offset, overlay_visible, socket_port
- Common key codes reference table