### PR TITLE
Lower minSdk to 28 for Android 9+ compatibility

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.droidrun.portal"
-        minSdk = 30
+        minSdk = 28
         targetSdk = 34
         versionCode = (project.findProperty("versionCode") as String).toInt()
         versionName = project.findProperty("versionName") as String

--- a/app/src/main/java/com/droidrun/portal/service/DroidrunAccessibilityService.kt
+++ b/app/src/main/java/com/droidrun/portal/service/DroidrunAccessibilityService.kt
@@ -718,6 +718,12 @@ class DroidrunAccessibilityService : AccessibilityService(), ConfigManager.Confi
     fun takeScreenshotBase64(hideOverlay: Boolean = true): CompletableFuture<String> {
         val future = CompletableFuture<String>()
 
+        // Check if screenshot API is available (API 34+)
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            future.complete("error: Screenshot API requires Android 14 (API 34) or higher")
+            return future
+        }
+
         // Temporarily hide overlay if requested
         val wasOverlayDrawingEnabled = if (hideOverlay) {
             val enabled = overlayManager.isDrawingEnabled()
@@ -739,16 +745,17 @@ class DroidrunAccessibilityService : AccessibilityService(), ConfigManager.Confi
         } catch (e: Exception) {
             Log.e(TAG, "Error taking screenshot", e)
             future.complete("error: Failed to take screenshot: ${e.message}")
-            
+
             // Restore overlay drawing state in case of exception
             if (hideOverlay) {
                 overlayManager.setDrawingEnabled(wasOverlayDrawingEnabled)
             }
         }
-        
+
         return future
     }
     
+    @androidx.annotation.RequiresApi(android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     private fun performScreenshotCapture(future: CompletableFuture<String>, wasOverlayDrawingEnabled: Boolean, hideOverlay: Boolean) {
         try {
             takeScreenshot(


### PR DESCRIPTION
Fixes #27

### Changes
- Lower minSdk from 30 to 28 in build.gradle.kts
- Add API 34+ version check for screenshot functionality
- Add `@RequiresApi` annotation to prevent API violations

### Impact
The app can now be installed on Android 9+ devices instead of requiring Android 11+. This resolves the installation failure on Android 10 devices (like Redmi 8).

Screenshot functionality will return an error on devices below Android 14, but all other features work normally.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/droidrun/droidrun-portal/actions/runs/19783729777) | [Branch](https://github.com/droidrun/droidrun-portal/tree/claude/issue-27-20251129-1215