### PR TITLE
fix: reset apiHandler on accessbility service reconnected

### DIFF
--- a/app/src/main/java/com/droidrun/portal/service/DroidrunAccessibilityService.kt
+++ b/app/src/main/java/com/droidrun/portal/service/DroidrunAccessibilityService.kt
@@ -20,6 +20,7 @@ import android.os.Handler
 import android.os.Looper
 import java.util.concurrent.atomic.AtomicBoolean
 import android.graphics.Bitmap
+import android.net.Uri
 import android.util.Base64
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.CompletableFuture
@@ -95,6 +96,14 @@ class DroidrunAccessibilityService : AccessibilityService(), ConfigManager.Confi
         super.onServiceConnected()
         overlayManager.showOverlay()
         instance = this
+
+        contentResolver.call(Uri.Builder()
+            .scheme("content")
+            .authority("com.droidrun.portal")
+            .build(),
+            "resetApiHandler",
+            null, null
+        )
 
         serviceInfo = AccessibilityServiceInfo().apply {
             eventTypes = AccessibilityEvent.TYPES_ALL_MASK

--- a/app/src/main/java/com/droidrun/portal/service/DroidrunContentProvider.kt
+++ b/app/src/main/java/com/droidrun/portal/service/DroidrunContentProvider.kt
@@ -6,8 +6,10 @@ import android.content.UriMatcher
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
+import android.os.Bundle
 import android.util.Log
 import androidx.core.net.toUri
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.droidrun.portal.api.ApiHandler
 import com.droidrun.portal.api.ApiResponse
 import com.droidrun.portal.core.StateRepository
@@ -156,6 +158,15 @@ class DroidrunContentProvider : ContentProvider() {
              val errorMsg = (result as ApiResponse.Error).message
             "content://$AUTHORITY/result?status=error&message=${Uri.encode(errorMsg)}".toUri()
         }
+    }
+
+    override fun call(msg: String, arg: String?, extras: Bundle?): Bundle?{
+        when(msg) {
+            "resetApiHandler" -> {
+                apiHandler = null
+            }
+        }
+        return super.call(msg, arg, extras)
     }
 
     override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0


### PR DESCRIPTION
DroidrunAccessibilityService will be reconnected( and has a new instance) when you're using Uiautomator2(u2.jar). 
DroidrunContentProvider should reset its apiHandler when DroidrunAccessibilityService has a new instance