### PR TITLE
fix: correct JSON key from 'data' to 'result' in fetchElementData

### DIFF
--- a/app/src/main/java/com/droidrun/portal/ui/MainActivity.kt
+++ b/app/src/main/java/com/droidrun/portal/ui/MainActivity.kt
@@ -497,7 +497,7 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
                     val jsonResponse = JSONObject(result)
 
                     if (jsonResponse.getString("status") == "success") {
-                        val data = jsonResponse.getString("data")
+                        val data = jsonResponse.getString("result")
                         responseText = data
                         Toast.makeText(
                             this,


### PR DESCRIPTION
Fixes #55

## Summary
Fixed the bug where clicking "Test Fetching" always resulted in an error.

## Changes
- Updated MainActivity.kt to use the correct JSON key `"result"` instead of `"data"` in the fetchElementData method

## Testing
The "Test Fetching" button should now work correctly and successfully retrieve combined state data.

Generated with [Claude Code](https://claude.ai/code)