### PR TITLE
feat: add task runner card to main screen

### DIFF
--- a/app/src/main/java/com/droidrun/portal/api/TaskRunnerClient.kt
+++ b/app/src/main/java/com/droidrun/portal/api/TaskRunnerClient.kt
@@ -1,0 +1,197 @@
+package com.droidrun.portal.api
+
+import android.util.Log
+import org.json.JSONObject
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Synchronous HTTP client for the Droidrun Cloud Tasks API.
+ * All methods are blocking and must be called from a background thread.
+ */
+object TaskRunnerClient {
+
+    private const val TAG = "TaskRunnerClient"
+    private const val BASE_URL = "https://dev-api.droidrun.ai/v1/tasks"
+    private const val CONNECT_TIMEOUT_MS = 15_000
+    private const val READ_TIMEOUT_MS = 30_000
+
+    data class TaskCreatedResponse(val id: String, val streamUrl: String, val token: String)
+    data class TaskStatusResponse(val status: String)
+    data class TaskDetailResponse(
+        val status: String,
+        val succeeded: Boolean?,
+        val output: String?,
+        val steps: Int?,
+        val task: String
+    )
+
+    class TaskApiException(val httpCode: Int, message: String) : Exception(message)
+
+    fun createTask(
+        apiKey: String,
+        deviceId: String,
+        taskDescription: String,
+        userAgent: String
+    ): TaskCreatedResponse {
+        val body = JSONObject().apply {
+            put("task", taskDescription)
+            put("llmModel", "google/gemini-3-flash")
+            put("deviceId", deviceId)
+            put("stealth", false)
+            put("reasoning", true)
+        }
+
+        val connection = openConnection(BASE_URL, "POST", apiKey, userAgent)
+        try {
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.outputStream.use { os ->
+                os.write(body.toString().toByteArray(Charsets.UTF_8))
+            }
+
+            val code = connection.responseCode
+            if (code !in 200..299) {
+                val errorBody = readErrorBody(connection)
+                Log.w(TAG, "createTask failed: HTTP $code — $errorBody")
+                throw TaskApiException(code, parseErrorMessage(errorBody, code))
+            }
+
+            val responseBody = connection.inputStream.bufferedReader().use { it.readText() }
+            val json = JSONObject(responseBody)
+            return TaskCreatedResponse(
+                id = json.getString("id"),
+                streamUrl = json.optString("streamUrl", ""),
+                token = json.optString("token", "")
+            )
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    fun cancelTask(apiKey: String, taskId: String, userAgent: String): Boolean {
+        val url = "$BASE_URL/$taskId/cancel"
+        val connection = openConnection(url, "POST", apiKey, userAgent)
+        try {
+            connection.doOutput = true
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.outputStream.use { os ->
+                os.write("{}".toByteArray(Charsets.UTF_8))
+            }
+
+            val code = connection.responseCode
+            if (code !in 200..299) {
+                val errorBody = readErrorBody(connection)
+                Log.w(TAG, "cancelTask failed: HTTP $code — $errorBody")
+                return false
+            }
+            return true
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    fun getTaskStatus(apiKey: String, taskId: String, userAgent: String): TaskStatusResponse {
+        val url = "$BASE_URL/$taskId/status"
+        val connection = openConnection(url, "GET", apiKey, userAgent)
+        try {
+            val code = connection.responseCode
+            if (code !in 200..299) {
+                val errorBody = readErrorBody(connection)
+                Log.w(TAG, "getTaskStatus failed: HTTP $code — $errorBody")
+                throw TaskApiException(code, parseErrorMessage(errorBody, code))
+            }
+
+            val responseBody = connection.inputStream.bufferedReader().use { it.readText() }
+            val json = JSONObject(responseBody)
+            return TaskStatusResponse(status = json.getString("status"))
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    fun getTaskDetail(apiKey: String, taskId: String, userAgent: String): TaskDetailResponse {
+        val url = "$BASE_URL/$taskId"
+        val connection = openConnection(url, "GET", apiKey, userAgent)
+        try {
+            val code = connection.responseCode
+            if (code !in 200..299) {
+                val errorBody = readErrorBody(connection)
+                Log.w(TAG, "getTaskDetail failed: HTTP $code — $errorBody")
+                throw TaskApiException(code, parseErrorMessage(errorBody, code))
+            }
+
+            val responseBody = connection.inputStream.bufferedReader().use { it.readText() }
+            Log.d(TAG, "getTaskDetail response: ${responseBody.take(2000)}")
+            val json = JSONObject(responseBody)
+
+            // API wraps task data in a "task" key
+            val taskObj = json.optJSONObject("task") ?: json
+
+            val outputStr = when {
+                taskObj.isNull("output") -> null
+                else -> {
+                    val outputVal = taskObj.opt("output")
+                    when (outputVal) {
+                        is JSONObject -> outputVal.toString(2)
+                        is String -> outputVal
+                        null -> null
+                        else -> outputVal.toString()
+                    }
+                }
+            }
+
+            val succeeded = if (taskObj.isNull("succeeded")) null else taskObj.optBoolean("succeeded")
+
+            return TaskDetailResponse(
+                status = taskObj.optString("status", "unknown"),
+                succeeded = succeeded,
+                output = outputStr,
+                steps = if (taskObj.isNull("steps")) null else taskObj.optInt("steps"),
+                task = taskObj.optString("task", "")
+            )
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun openConnection(
+        urlString: String,
+        method: String,
+        apiKey: String,
+        userAgent: String
+    ): HttpURLConnection {
+        val connection = URL(urlString).openConnection() as HttpURLConnection
+        connection.requestMethod = method
+        connection.connectTimeout = CONNECT_TIMEOUT_MS
+        connection.readTimeout = READ_TIMEOUT_MS
+        connection.setRequestProperty("Authorization", "Bearer $apiKey")
+        connection.setRequestProperty("User-Agent", userAgent)
+        return connection
+    }
+
+    private fun readErrorBody(connection: HttpURLConnection): String {
+        return try {
+            connection.errorStream?.bufferedReader()?.use { reader ->
+                val text = reader.readText()
+                if (text.length > 1024) text.take(1024) else text
+            } ?: ""
+        } catch (e: IOException) {
+            ""
+        }
+    }
+
+    private fun parseErrorMessage(errorBody: String, httpCode: Int): String {
+        if (errorBody.isBlank()) return "HTTP $httpCode"
+        return try {
+            val json = JSONObject(errorBody)
+            json.optString("detail", null)
+                ?: json.optString("error", null)
+                ?: json.optString("message", null)
+                ?: "HTTP $httpCode"
+        } catch (e: Exception) {
+            errorBody.take(200)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -538,6 +538,111 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Task Runner Card -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/card_task_runner"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="0dp"
+                app:strokeWidth="0dp"
+                app:cardBackgroundColor="@color/background_card">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="16dp">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/task_runner_title"
+                        android:textColor="@color/text_white"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:layout_marginBottom="12dp" />
+
+                    <com.google.android.material.textfield.TextInputLayout
+                        android:id="@+id/task_input_layout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="12dp"
+                        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                        app:boxStrokeColor="@color/stroke_gray"
+                        app:hintTextColor="@color/text_gray">
+
+                        <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/task_input"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/task_runner_hint"
+                            android:textColor="@color/text_white"
+                            android:textSize="14sp"
+                            android:inputType="textMultiLine"
+                            android:minLines="2"
+                            android:maxLines="4"
+                            android:background="@color/background_input" />
+                    </com.google.android.material.textfield.TextInputLayout>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:id="@+id/task_status_text"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:textSize="13sp"
+                            android:textColor="@color/text_gray"
+                            android:visibility="gone" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_task_run"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/task_runner_run"
+                            android:textColor="@color/text_white"
+                            android:textSize="14sp"
+                            android:paddingVertical="8dp"
+                            app:cornerRadius="8dp"
+                            app:backgroundTint="@color/droidrun_primary" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btn_task_stop"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/task_runner_stop"
+                            android:textColor="@color/text_white"
+                            android:textSize="14sp"
+                            android:paddingVertical="8dp"
+                            android:visibility="gone"
+                            app:cornerRadius="8dp"
+                            app:backgroundTint="@color/status_error" />
+                    </LinearLayout>
+
+                    <!-- Task output / result area -->
+                    <TextView
+                        android:id="@+id/task_output_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="12dp"
+                        android:background="@color/background_code"
+                        android:padding="12dp"
+                        android:textColor="@color/text_gray_light"
+                        android:textSize="12sp"
+                        android:fontFamily="monospace"
+                        android:maxLines="10"
+                        android:scrollbars="vertical"
+                        android:textIsSelectable="true"
+                        android:visibility="gone" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,4 +106,23 @@
     <!-- Keyboard Warning -->
     <string name="keyboard_not_enabled_warning">Droidrun Keyboard not active. Using accessibility fallback for text input.</string>
     <string name="select_keyboard">Select</string>
+
+    <!-- Task Runner -->
+    <string name="task_runner_title">Run a Task</string>
+    <string name="task_runner_hint">Describe what you want the agent to do\u2026</string>
+    <string name="task_runner_run">Run</string>
+    <string name="task_runner_stop">Stop</string>
+    <string name="task_runner_status_running">Running\u2026</string>
+    <string name="task_runner_status_completed">Completed</string>
+    <string name="task_runner_status_failed">Failed</string>
+    <string name="task_runner_status_cancelled">Cancelled</string>
+    <string name="task_runner_no_credits">No credits remaining</string>
+    <string name="task_runner_invalid_key">Invalid API key</string>
+    <string name="task_runner_device_not_ready">Device not ready</string>
+    <string name="task_runner_server_error">Server error, try again later</string>
+    <string name="task_runner_network_error">Network error \u2014 check your connection</string>
+    <string name="task_runner_connect_first">Connect to cloud first</string>
+    <string name="task_runner_enable_a11y">Enable accessibility service first</string>
+    <string name="task_runner_notification_title">Task running</string>
+    <string name="task_runner_notification_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
Add inline "Run a Task" card that sends tasks to the Droidrun Cloud API. Includes task creation, status polling, cancellation, persistent notification with cancel action, and result display.