### PR TITLE
ci: support configurable portal artifact prefix

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,6 +9,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+env:
+  PORTAL_ARTIFACT_PREFIX: ${{ vars.PORTAL_ARTIFACT_PREFIX || 'com.mobilerun.portal' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -94,21 +97,23 @@ jobs:
         run: |
           set -euo pipefail
 
+          VERSION_NAME="${{ steps.version.outputs.VERSION_NAME }}"
+          ARTIFACT_PREFIX="${PORTAL_ARTIFACT_PREFIX}"
           DEBUG_APK="$(find app/build/outputs/apk/debug -maxdepth 1 -name '*.apk' | head -n1)"
           RELEASE_APK="$(find app/build/outputs/apk/release -maxdepth 1 -name '*-release*.apk' | head -n1)"
 
           [[ -n "${DEBUG_APK}" ]]
           [[ -n "${RELEASE_APK}" ]]
 
-          cp "${DEBUG_APK}" .
-          cp "${RELEASE_APK}" .
+          cp "${DEBUG_APK}" "${ARTIFACT_PREFIX}-${VERSION_NAME}-debug.apk"
+          cp "${RELEASE_APK}" "${ARTIFACT_PREFIX}-${VERSION_NAME}-release-unsigned.apk"
 
       - name: Upload APKs
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: apks
-          path: com.mobilerun.portal-*.apk
+          path: ${{ env.PORTAL_ARTIFACT_PREFIX }}-*.apk
           retention-days: 1
 
       - name: Upload debug APK
@@ -145,7 +150,7 @@ jobs:
     uses: ./.github/workflows/deploy-r2.yml
     with:
       artifact-name: apks
-      file-prefix: com.mobilerun.portal
+      file-prefix: ${{ vars.PORTAL_ARTIFACT_PREFIX || 'com.mobilerun.portal' }}
       tag: ${{ needs.build.outputs.version-name }}
     secrets:
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}

--- a/.github/workflows/deploy-r2.yml
+++ b/.github/workflows/deploy-r2.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       file-prefix:
-        description: "Filename prefix for the APK (e.g. com.mobilerun.portal)"
+        description: "Filename prefix for the APK (e.g. com.mobilerun.portal or mobilerun-portal-internal)"
         required: true
         type: string
       tag:


### PR DESCRIPTION
## Summary
- Add `PORTAL_ARTIFACT_PREFIX` workflow configuration with default `com.mobilerun.portal`.
- Rename tag release APK artifacts to include the selected prefix and resolved version.
- Document `mobilerun-portal-internal` as an allowed deploy filename prefix convention.

## Why
This keeps the Android package identity as `com.mobilerun.portal` while allowing internal artifact/repo naming conventions for future releases.

## Validation
- `git diff --check` passed.
- Branch is based on current `origin/main`.
- No portal APK retag or new portal release was created.