### PR TITLE
fix: API tree fetch returns empty when rootInActiveWindow flakes (e.g. Tuya Smart)

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
@@ -11,9 +11,29 @@ class StateRepository(private val service: MobilerunAccessibilityService?) {
     fun getVisibleElements(): List<ElementNode> = service?.getVisibleElements() ?: emptyList()
 
     fun getFullTree(filter: Boolean): JSONObject? {
-        val root = service?.rootInActiveWindow ?: return null
-        val bounds = if (filter) service.getScreenBounds() else null
+        val svc = service ?: return null
+        val root = svc.rootInActiveWindow ?: pickFallbackRoot(svc) ?: return null
+        val bounds = if (filter) svc.getScreenBounds() else null
         return AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root, bounds)
+    }
+
+    /**
+     * Falls back to enumerating accessibility windows when `rootInActiveWindow`
+     * returns null. Picks the topmost user-facing window with a non-null root.
+     * Requires `flagRetrieveInteractiveWindows` in the service config.
+     */
+    private fun pickFallbackRoot(svc: MobilerunAccessibilityService): android.view.accessibility.AccessibilityNodeInfo? {
+        val ws = svc.windows ?: return null
+        return try {
+            ws.sortedByDescending { it.layer }
+                .firstOrNull {
+                    it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_APPLICATION ||
+                    it.type == android.view.accessibility.AccessibilityWindowInfo.TYPE_SYSTEM
+                }
+                ?.root
+        } finally {
+            ws.forEach { it.recycle() }
+        }
     }
 
     fun getPhoneState(): PhoneState =

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -594,14 +594,21 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         val elements = mutableListOf<ElementNode>()
         val indexCounter = IndexCounter(1)
 
-        val rootNode = rootInActiveWindow ?: return elements
+        val rootCandidates = collectRootCandidates()
+        if (rootCandidates.isEmpty()) {
+            // Nothing queryable right now (active window flake, or no a11y windows yet).
+            // Preserve the previous snapshot so callers don't see a transient empty.
+            synchronized(visibleElements) {
+                return visibleElements.toMutableList()
+            }
+        }
+
         try {
-            val rootElement = findAllVisibleElements(rootNode, 0, null, indexCounter)
-            rootElement?.let {
-                collectRootElements(it, elements)
+            for ((rootNode, layer) in rootCandidates) {
+                walkAsRoot(rootNode, layer, elements, indexCounter)
             }
         } finally {
-            rootNode.recycle()
+            rootCandidates.forEach { (node, _) -> node.recycle() }
         }
 
         synchronized(visibleElements) {
@@ -610,6 +617,67 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         }
 
         return elements
+    }
+
+    /**
+     * Returns one or more root [AccessibilityNodeInfo]s to walk for the current
+     * screen, paired with their window layer. Tries `rootInActiveWindow` first
+     * (cheap, common case). When that's null — which can happen on apps whose
+     * outermost window flakes through `rootInActiveWindow` mid-transition or
+     * when an accessibility overlay claims focus — falls back to enumerating
+     * `windows` and picking the topmost user-facing roots. Requires
+     * `flagRetrieveInteractiveWindows` in the service config for the fallback
+     * to populate `windows`.
+     */
+    private fun collectRootCandidates(): List<Pair<AccessibilityNodeInfo, Int>> {
+        rootInActiveWindow?.let { return listOf(it to 0) }
+        val ws = windows ?: return emptyList()
+        val out = mutableListOf<Pair<AccessibilityNodeInfo, Int>>()
+        try {
+            ws.sortedByDescending { it.layer }
+                .filter {
+                    it.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
+                    it.type == AccessibilityWindowInfo.TYPE_SYSTEM
+                }
+                .forEach { w ->
+                    val r = w.root
+                    if (r != null) out.add(r to w.layer)
+                }
+        } finally {
+            ws.forEach { it.recycle() }
+        }
+        return out
+    }
+
+    /**
+     * Walks [rootNode] and accumulates visible elements into [elements].
+     * If the root itself is filtered (e.g. zero-size wrapper before first
+     * layout), its direct children are walked as fresh roots so their subtrees
+     * aren't orphaned by the `parent?.addChild` no-op.
+     */
+    private fun walkAsRoot(
+        rootNode: AccessibilityNodeInfo,
+        windowLayer: Int,
+        elements: MutableList<ElementNode>,
+        indexCounter: IndexCounter,
+    ) {
+        val rootElement = findAllVisibleElements(rootNode, windowLayer, null, indexCounter)
+        if (rootElement != null) {
+            collectRootElements(rootElement, elements)
+            return
+        }
+        // Root was filtered out — promote its visible descendants to roots.
+        for (i in 0 until rootNode.childCount) {
+            val childNode = rootNode.getChild(i) ?: continue
+            try {
+                val childRoot = findAllVisibleElements(childNode, windowLayer, null, indexCounter)
+                if (childRoot != null) {
+                    collectRootElements(childRoot, elements)
+                }
+            } finally {
+                childNode.recycle()
+            }
+        }
     }
 
     private fun collectRootElements(element: ElementNode, rootElements: MutableList<ElementNode>) {

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -3,7 +3,7 @@
     android:description="@string/accessibility_service_description"
     android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagIncludeNotImportantViews|flagReportViewIds"
+    android:accessibilityFlags="flagIncludeNotImportantViews|flagReportViewIds|flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"
     android:canTakeScreenshot="true"
     android:canPerformGestures="true"


### PR DESCRIPTION
## Symptom

On certain apps (reproduced consistently with **Tuya Smart 7.6.2** on Android 16 Pixel 8), the visual overlay correctly highlights every clickable element on screen, but `/a11y_tree`, `/a11y_tree_full`, and the WebSocket tree query return empty / `"No active window or root filtered out"`. Same screen, divergent results between the overlay code path and the API code path.

Repro before this PR (with v0.7.1 installed and accessibility service granted):
```
$ adb shell content query --uri content://com.mobilerun.portal/a11y_tree
Row: 0 result={"status":"success","result":"[]"}
$ adb shell content query --uri content://com.mobilerun.portal/a11y_tree_full
Row: 0 result={"status":"error","error":"No active window or root filtered out"}
```

After:
```
$ adb shell content query --uri content://com.mobilerun.portal/a11y_tree
Row: 0 result={"status":"success","result":"[{\"index\":1,\"resourceId\":\"\",\"className\":\"FrameLayout\",...}, ...]"}  # 1.7 KB
```

## Root cause

Three concurrent issues, all in the API tree-fetch code path:

1. `accessibility_service_config.xml` lacked `flagRetrieveInteractiveWindows`, so `service.windows` was always `null`. No fallback when `rootInActiveWindow` was unavailable.
2. `getVisibleElementsInternal()` and `StateRepository.getFullTree()` used `rootInActiveWindow` as the only source. When it returned `null` mid-transition or because an accessibility overlay claimed focus, the API got empty while the overlay (driven by `onAccessibilityEvent` callbacks) still had cached state from a prior refresh.
3. `findAllVisibleElements()` orphans entire subtrees when the root node fails the in-screen / min-size filter (e.g. zero-bounds wrapper before first layout): `currentElement` stays `null`, recursion still walks children, but `parent?.addChild(...)` no-ops and the returned `currentElement` is `null` — every descendant is lost.

## Fixes

- **Add `flagRetrieveInteractiveWindows`** to the service config so `service.windows` is populated for the fallback path.
- **`collectRootCandidates()`** in `MobilerunAccessibilityService`: try `rootInActiveWindow` first, fall back to enumerating `windows` and picking topmost `TYPE_APPLICATION` / `TYPE_SYSTEM` roots.
- **`walkAsRoot()`**: when the root is filtered out, promote its direct children to roots so their subtrees aren't orphaned.
- **`StateRepository.getFullTree()`**: mirror the windows-fallback path.
- **Snapshot fallback**: when no root is queryable at all, return the previous `visibleElements` snapshot instead of a transient empty list. Avoids blanking out callers during brief flakes.

## Verification

Sideloaded a fork-CI debug build of this branch on a Pixel 8 / Android 16 / Tuya Smart 7.6.2:

| screen | `/a11y_tree` before | `/a11y_tree` after |
|---|---|---|
| Tuya User Agreement dialog | 49 b empty | **1773 b** rich JSON |
| Tuya login (Log In / Sign Up / Try as Guest) | 49 b empty | **683 b**, all 3 buttons + bounds |
| Settings (homepage) | 2.9 KB ✓ | 2.9 KB ✓ (unchanged) |

Diff is 96 insertions / 8 deletions across 3 files; no API changes, no manifest changes, no behavioral change on apps that already worked.