### PR TITLE
Guard accessibility traversal against cyclic node trees

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -49,6 +49,8 @@ import android.app.NotificationManager
 import androidx.core.app.NotificationCompat
 import com.mobilerun.portal.state.AppVisibilityTracker
 import com.mobilerun.portal.ui.PermissionDialogActivity
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.Locale
 
 class ApiHandler(
@@ -1203,7 +1205,11 @@ class ApiHandler(
         elements: List<com.mobilerun.portal.model.ElementNode>
     ): List<com.mobilerun.portal.model.ElementNode> {
         val all = mutableListOf<com.mobilerun.portal.model.ElementNode>()
+        val visited = Collections.newSetFromMap(
+            IdentityHashMap<com.mobilerun.portal.model.ElementNode, Boolean>()
+        )
         fun collect(node: com.mobilerun.portal.model.ElementNode) {
+            if (!visited.add(node)) return
             all.add(node)
             node.children.forEach { child -> collect(child) }
         }

--- a/app/src/main/java/com/mobilerun/portal/model/ElementNode.kt
+++ b/app/src/main/java/com/mobilerun/portal/model/ElementNode.kt
@@ -2,6 +2,8 @@ package com.mobilerun.portal.model
 
 import android.graphics.Rect
 import android.view.accessibility.AccessibilityNodeInfo
+import java.util.Collections
+import java.util.IdentityHashMap
 import kotlin.math.max
 import kotlin.math.min
 
@@ -25,6 +27,10 @@ data class ElementNode(
 ) {
     companion object {
         private const val FADE_DURATION_MS = 60000L // Time to fade from weight 1.0 to 0.0 (60 seconds)
+
+        private fun visitedSet(): MutableSet<ElementNode> {
+            return Collections.newSetFromMap(IdentityHashMap<ElementNode, Boolean>())
+        }
 
         /**
          * Creates a unique ID for an element based on its properties
@@ -71,8 +77,9 @@ data class ElementNode(
 
         var current = this
         var level = 0
+        val visited = visitedSet()
 
-        while (current.parent != null) {
+        while (current.parent != null && visited.add(current)) {
             level++
             current = current.parent!!
         }
@@ -84,7 +91,8 @@ data class ElementNode(
     // Get the root ancestor
     fun getRootAncestor(): ElementNode {
         var current = this
-        while (current.parent != null) {
+        val visited = visitedSet()
+        while (current.parent != null && visited.add(current)) {
             current = current.parent!!
         }
         return current
@@ -92,6 +100,9 @@ data class ElementNode(
 
     // Add a child node
     fun addChild(child: ElementNode) {
+        if (child === this || hasAncestor(child)) {
+            return
+        }
         if (!children.contains(child)) {
             children.add(child)
             child.parent = this
@@ -106,10 +117,16 @@ data class ElementNode(
 
     // Get all descendants (children, grandchildren, etc.)
     fun getAllDescendants(): List<ElementNode> {
+        return getAllDescendants(visitedSet())
+    }
+
+    private fun getAllDescendants(visited: MutableSet<ElementNode>): List<ElementNode> {
+        if (!visited.add(this)) return emptyList()
         val descendants = mutableListOf<ElementNode>()
         for (child in children) {
+            if (child in visited) continue
             descendants.add(child)
-            descendants.addAll(child.getAllDescendants())
+            descendants.addAll(child.getAllDescendants(visited))
         }
         return descendants
     }
@@ -118,11 +135,22 @@ data class ElementNode(
     fun getPathFromRoot(): List<ElementNode> {
         val path = mutableListOf<ElementNode>()
         var current: ElementNode? = this
-        while (current != null) {
+        val visited = visitedSet()
+        while (current != null && visited.add(current)) {
             path.add(0, current)
             current = current.parent
         }
         return path
+    }
+
+    private fun hasAncestor(candidate: ElementNode): Boolean {
+        var current = parent
+        val visited = visitedSet()
+        while (current != null && visited.add(current)) {
+            if (current === candidate) return true
+            current = current.parent
+        }
+        return false
     }
 
     override fun toString(): String {

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -53,6 +53,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
             "com.mobilerun.portal.action.DISABLE_LOCAL_WS_SERVER"
         private var instance: MobilerunAccessibilityService? = null
         private const val MIN_ELEMENT_SIZE = 5
+        private const val MAX_ACCESSIBILITY_TREE_DEPTH = 128
         private const val TOAST_DEBOUNCE_MS = 60_000L
         private const val AUTO_ACCEPT_FAILURE_TOAST_DEBOUNCE_MS = 10_000L
         private const val LOCAL_WS_NOTIFICATION_CHANNEL_ID = "local_ws_connection_channel"
@@ -593,9 +594,21 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         val elements = mutableListOf<ElementNode>()
         val indexCounter = IndexCounter(1)
 
-        val rootNode = rootInActiveWindow ?: return elements
+        val rootNode = try {
+            rootInActiveWindow
+        } catch (e: RuntimeException) {
+            Log.e(TAG, "Unable to read active accessibility root: ${e.message}", e)
+            null
+        } ?: return elements
         try {
-            val rootElement = findAllVisibleElements(rootNode, 0, null, indexCounter)
+            val rootElement = findAllVisibleElements(
+                node = rootNode,
+                windowLayer = 0,
+                parent = null,
+                indexCounter = indexCounter,
+                depth = 0,
+                activeNodeKeys = mutableSetOf()
+            )
             rootElement?.let {
                 collectRootElements(it, elements)
             }
@@ -619,86 +632,126 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         node: AccessibilityNodeInfo,
         windowLayer: Int,
         parent: ElementNode?,
-        indexCounter: IndexCounter
+        indexCounter: IndexCounter,
+        depth: Int,
+        activeNodeKeys: MutableSet<String>
     ): ElementNode? {
         try {
+            if (depth > MAX_ACCESSIBILITY_TREE_DEPTH) {
+                Log.w(TAG, "Skipping accessibility subtree deeper than $MAX_ACCESSIBILITY_TREE_DEPTH levels")
+                return null
+            }
 
             val rect = Rect()
             node.getBoundsInScreen(rect)
 
-            val isInScreen = Rect.intersects(rect, screenBounds)
-            val hasSize = rect.width() > MIN_ELEMENT_SIZE && rect.height() > MIN_ELEMENT_SIZE
-
-            var currentElement: ElementNode? = null
-
-            if (isInScreen && hasSize) {
-                val text = node.text?.toString() ?: ""
-                val contentDesc = node.contentDescription?.toString() ?: ""
-                val className = node.className?.toString() ?: ""
-                val viewId = node.viewIdResourceName ?: ""
-
-                val displayText = when {
-                    text.isNotEmpty() -> text
-                    contentDesc.isNotEmpty() -> contentDesc
-                    viewId.isNotEmpty() -> viewId.substringAfterLast('/')
-                    else -> className.substringAfterLast('.')
-                }
-
-                val elementType = if (node.isClickable) {
-                    "Clickable"
-                } else if (node.isCheckable) {
-                    "Checkable"
-                } else if (node.isEditable) {
-                    "Input"
-                } else if (text.isNotEmpty()) {
-                    "Text"
-                } else if (node.isScrollable) {
-                    "Container"
-                } else {
-                    "View"
-                }
-
-                val id = ElementNode.createId(rect, className.substringAfterLast('.'), displayText)
-
-                val nodeCopy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                    AccessibilityNodeInfo(node)
-                } else {
-                    @Suppress("DEPRECATION")
-                    AccessibilityNodeInfo.obtain(node)
-                }
-                currentElement = ElementNode(
-                    nodeCopy,
-                    Rect(rect),
-                    displayText,
-                    className.substringAfterLast('.'),
-                    windowLayer,
-                    System.currentTimeMillis(),
-                    id
-                )
-
-                // Assign unique index
-                currentElement.overlayIndex = indexCounter.getNext()
-
-                // Set parent-child relationship
-                parent?.addChild(currentElement)
+            val nodeKey = createTraversalKey(node, rect)
+            if (!activeNodeKeys.add(nodeKey)) {
+                Log.w(TAG, "Skipping cyclic accessibility node: $nodeKey")
+                return null
             }
 
-            // Recursively process children
-            for (i in 0 until node.childCount) {
-                val childNode = node.getChild(i) ?: continue
-                try {
-                    findAllVisibleElements(childNode, windowLayer, currentElement, indexCounter)
-                } finally {
-                    childNode.recycle()
-                }
-            }
+            try {
+                val isInScreen = Rect.intersects(rect, screenBounds)
+                val hasSize = rect.width() > MIN_ELEMENT_SIZE && rect.height() > MIN_ELEMENT_SIZE
 
-            return currentElement
+                var currentElement: ElementNode? = null
+
+                if (isInScreen && hasSize) {
+                    val text = node.text?.toString() ?: ""
+                    val contentDesc = node.contentDescription?.toString() ?: ""
+                    val className = node.className?.toString() ?: ""
+                    val viewId = node.viewIdResourceName ?: ""
+
+                    val displayText = when {
+                        text.isNotEmpty() -> text
+                        contentDesc.isNotEmpty() -> contentDesc
+                        viewId.isNotEmpty() -> viewId.substringAfterLast('/')
+                        else -> className.substringAfterLast('.')
+                    }
+
+                    val elementType = if (node.isClickable) {
+                        "Clickable"
+                    } else if (node.isCheckable) {
+                        "Checkable"
+                    } else if (node.isEditable) {
+                        "Input"
+                    } else if (text.isNotEmpty()) {
+                        "Text"
+                    } else if (node.isScrollable) {
+                        "Container"
+                    } else {
+                        "View"
+                    }
+
+                    val id = ElementNode.createId(rect, className.substringAfterLast('.'), displayText)
+
+                    val nodeCopy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                        AccessibilityNodeInfo(node)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        AccessibilityNodeInfo.obtain(node)
+                    }
+                    currentElement = ElementNode(
+                        nodeCopy,
+                        Rect(rect),
+                        displayText,
+                        className.substringAfterLast('.'),
+                        windowLayer,
+                        System.currentTimeMillis(),
+                        id
+                    )
+
+                    // Assign unique index
+                    currentElement.overlayIndex = indexCounter.getNext()
+
+                    // Set parent-child relationship
+                    parent?.addChild(currentElement)
+                }
+
+                // Recursively process children
+                for (i in 0 until node.childCount) {
+                    val childNode = node.getChild(i) ?: continue
+                    try {
+                        findAllVisibleElements(
+                            node = childNode,
+                            windowLayer = windowLayer,
+                            parent = currentElement,
+                            indexCounter = indexCounter,
+                            depth = depth + 1,
+                            activeNodeKeys = activeNodeKeys
+                        )
+                    } finally {
+                        childNode.recycle()
+                    }
+                }
+
+                return currentElement
+            } finally {
+                activeNodeKeys.remove(nodeKey)
+            }
 
         } catch (e: Exception) {
             Log.e(TAG, "Error in findAllVisibleElements: ${e.message}", e)
             return null
         }
+    }
+
+    private fun createTraversalKey(node: AccessibilityNodeInfo, rect: Rect): String {
+        val packageName = node.packageName?.toString().orEmpty()
+        val className = node.className?.toString().orEmpty()
+        val viewId = node.viewIdResourceName.orEmpty()
+        val text = node.text?.toString().orEmpty()
+        val contentDescription = node.contentDescription?.toString().orEmpty()
+        return listOf(
+            node.windowId.toString(),
+            rect.flattenToString(),
+            className,
+            viewId,
+            text.take(64),
+            contentDescription.take(64),
+            packageName,
+        ).joinToString("|")
     }
 
     fun getPhoneState(): PhoneState {

--- a/app/src/test/java/com/mobilerun/portal/model/ElementNodeTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/model/ElementNodeTest.kt
@@ -1,0 +1,62 @@
+package com.mobilerun.portal.model
+
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ElementNodeTest {
+
+    @Test
+    fun addChildIgnoresSelfReference() {
+        val element = elementNode("root")
+
+        element.addChild(element)
+
+        assertTrue(element.children.isEmpty())
+        assertNull(element.parent)
+    }
+
+    @Test
+    fun addChildIgnoresAncestorReference() {
+        val parent = elementNode("parent")
+        val child = elementNode("child")
+        parent.addChild(child)
+
+        child.addChild(parent)
+
+        assertEquals(listOf(child), parent.children)
+        assertTrue(child.children.isEmpty())
+        assertNull(parent.parent)
+        assertEquals(parent, child.parent)
+    }
+
+    @Test
+    fun descendantAndPathHelpersTerminateWhenCycleAlreadyExists() {
+        val parent = elementNode("parent")
+        val child = elementNode("child")
+        parent.children.add(child)
+        child.parent = parent
+        child.children.add(parent)
+        parent.parent = child
+
+        assertEquals(listOf(child), parent.getAllDescendants())
+        assertEquals(listOf(child, parent), parent.getPathFromRoot())
+        assertEquals(2, parent.calculateNestingLevel())
+    }
+
+    private fun elementNode(id: String): ElementNode {
+        return ElementNode(
+            nodeInfo = mockk<AccessibilityNodeInfo>(relaxed = true),
+            rect = Rect(0, 0, 10, 10),
+            text = id,
+            className = "TextView",
+            windowLayer = 0,
+            creationTime = 0L,
+            id = id
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add cycle and depth guards while traversing AccessibilityNodeInfo trees so malformed app nodes cannot recurse forever
- catch root access failures and return an empty snapshot instead of crashing the service
- make ElementNode child/path/descendant traversal cycle-safe and guard API flattening
- add unit coverage for ElementNode cycle handling

Fixes droidrun/mobilerun#87.

## Verification
- JAVA_HOME=/usr/local/opt/openjdk ANDROID_HOME=/usr/local/share/android-commandlinetools ./gradlew testDebugUnitTest