### PR TITLE
fix(a11y): recover tree from interactive windows

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
@@ -25,7 +25,10 @@ class StateRepository(private val service: MobilerunAccessibilityService?) {
     private fun pickFallbackRoot(svc: MobilerunAccessibilityService): AccessibilityNodeInfo? {
         val windows = svc.windows ?: return null
         return try {
-            windows.sortedByDescending { it.layer }
+            windows.sortedWith(
+                compareBy<AccessibilityWindowInfo> { fallbackWindowTypePriority(it) }
+                    .thenByDescending { it.layer }
+            )
                 .asSequence()
                 .filter { isUserFacingWindow(it) }
                 .mapNotNull { it.root }
@@ -38,6 +41,14 @@ class StateRepository(private val service: MobilerunAccessibilityService?) {
     private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
         return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
                 window.type == AccessibilityWindowInfo.TYPE_SYSTEM
+    }
+
+    private fun fallbackWindowTypePriority(window: AccessibilityWindowInfo): Int {
+        return when (window.type) {
+            AccessibilityWindowInfo.TYPE_APPLICATION -> 0
+            AccessibilityWindowInfo.TYPE_SYSTEM -> 1
+            else -> 2
+        }
     }
 
     fun getPhoneState(): PhoneState =

--- a/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
@@ -1,6 +1,8 @@
 package com.mobilerun.portal.core
 
 import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
 import com.mobilerun.portal.service.MobilerunAccessibilityService
 import com.mobilerun.portal.model.ElementNode
 import com.mobilerun.portal.model.PhoneState
@@ -14,9 +16,28 @@ class StateRepository(private val service: MobilerunAccessibilityService?) {
     fun getVisibleElements(): List<ElementNode> = service?.getVisibleElements() ?: emptyList()
 
     fun getFullTree(filter: Boolean): JSONObject? {
-        val root = service?.rootInActiveWindow ?: return null
-        val bounds = if (filter) service.getScreenBounds() else null
+        val svc = service ?: return null
+        val root = svc.rootInActiveWindow ?: pickFallbackRoot(svc) ?: return null
+        val bounds = if (filter) svc.getScreenBounds() else null
         return AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root, bounds)
+    }
+
+    private fun pickFallbackRoot(svc: MobilerunAccessibilityService): AccessibilityNodeInfo? {
+        val windows = svc.windows ?: return null
+        return try {
+            windows.sortedByDescending { it.layer }
+                .asSequence()
+                .filter { isUserFacingWindow(it) }
+                .mapNotNull { it.root }
+                .firstOrNull()
+        } finally {
+            windows.forEach { it.recycle() }
+        }
+    }
+
+    private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
+        return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
+                window.type == AccessibilityWindowInfo.TYPE_SYSTEM
     }
 
     fun getPhoneState(): PhoneState =

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -665,7 +665,10 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         val windows = windows ?: return emptyList()
         val out = mutableListOf<Pair<AccessibilityNodeInfo, Int>>()
         try {
-            windows.sortedByDescending { it.layer }
+            windows.sortedWith(
+                compareBy<AccessibilityWindowInfo> { fallbackWindowTypePriority(it) }
+                    .thenByDescending { it.layer }
+            )
                 .filter { isUserFacingWindow(it) }
                 .forEach { window ->
                     val root = window.root
@@ -682,6 +685,14 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
     private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
         return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
                 window.type == AccessibilityWindowInfo.TYPE_SYSTEM
+    }
+
+    private fun fallbackWindowTypePriority(window: AccessibilityWindowInfo): Int {
+        return when (window.type) {
+            AccessibilityWindowInfo.TYPE_APPLICATION -> 0
+            AccessibilityWindowInfo.TYPE_SYSTEM -> 1
+            else -> 2
+        }
     }
 
     private fun collectVisibleElements(

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -57,10 +57,28 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         private const val AUTO_ACCEPT_FAILURE_TOAST_DEBOUNCE_MS = 10_000L
         private const val LOCAL_WS_NOTIFICATION_CHANNEL_ID = "local_ws_connection_channel"
         private const val LOCAL_WS_NOTIFICATION_ID = 2003
+        internal const val VISIBLE_ELEMENTS_STALE_GRACE_MS = 750L
 
         // Periodic update constants
         private const val REFRESH_INTERVAL_MS = 250L // Update every 250ms
         private const val MIN_FRAME_TIME_MS = 16L // Minimum time between frames (roughly 60 FPS)
+
+        internal fun shouldReuseVisibleElementsSnapshot(
+            cachedElementCount: Int,
+            snapshotTimeMs: Long,
+            nowMs: Long,
+            snapshotPackageName: String,
+            currentPackageName: String,
+            snapshotActivityName: String,
+            currentActivityName: String,
+        ): Boolean {
+            val snapshotAgeMs = nowMs - snapshotTimeMs
+            return cachedElementCount > 0 &&
+                    snapshotTimeMs > 0L &&
+                    snapshotAgeMs in 0L..VISIBLE_ELEMENTS_STALE_GRACE_MS &&
+                    snapshotPackageName == currentPackageName &&
+                    snapshotActivityName == currentActivityName
+        }
 
         fun getInstance(): MobilerunAccessibilityService? = instance
 
@@ -169,6 +187,9 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
     private var currentPackageName: String = ""
     private var currentActivityName: String = ""
     private val visibleElements = mutableListOf<ElementNode>()
+    private var visibleElementsSnapshotTimeMs = 0L
+    private var visibleElementsSnapshotPackageName = ""
+    private var visibleElementsSnapshotActivityName = ""
 
     override fun onCreate() {
         super.onCreate()
@@ -381,17 +402,15 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
             if (currentPackageName.isEmpty()) {
                 overlayManager.clearElements()
                 overlayManager.refreshOverlay()
+                clearVisibleElementSnapshot()
                 return
             }
-
-            // Clear previous elements
-            clearElementList()
 
             // Get fresh elements
             val elements = getVisibleElementsInternal()
 
             // Update overlay if visible
-            if (configManager.overlayVisible && elements.isNotEmpty()) {
+            if (configManager.overlayVisible) {
                 overlayManager.clearElements()
 
                 elements.forEach { rootElement ->
@@ -418,7 +437,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         try {
             overlayManager.clearElements()
             overlayManager.refreshOverlay()
-            clearElementList()
+            clearVisibleElementSnapshot()
             Log.d(TAG, "Reset overlay state for package change")
         } catch (e: Exception) {
             Log.e(TAG, "Error resetting overlay state: ${e.message}", e)
@@ -434,6 +453,13 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
             }
         }
         visibleElements.clear()
+    }
+
+    private fun clearVisibleElementSnapshot() {
+        clearElementList()
+        visibleElementsSnapshotTimeMs = 0L
+        visibleElementsSnapshotPackageName = ""
+        visibleElementsSnapshotActivityName = ""
     }
 
     private fun applyConfiguration() {
@@ -593,34 +619,78 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         val elements = mutableListOf<ElementNode>()
         val indexCounter = IndexCounter(1)
 
-        val rootNode = rootInActiveWindow ?: return elements
+        val rootCandidates = collectRootCandidates()
+        if (rootCandidates.isEmpty()) {
+            synchronized(visibleElements) {
+                if (shouldReuseVisibleElementsSnapshot(
+                        cachedElementCount = visibleElements.size,
+                        snapshotTimeMs = visibleElementsSnapshotTimeMs,
+                        nowMs = SystemClock.elapsedRealtime(),
+                        snapshotPackageName = visibleElementsSnapshotPackageName,
+                        currentPackageName = currentPackageName,
+                        snapshotActivityName = visibleElementsSnapshotActivityName,
+                        currentActivityName = currentActivityName,
+                    )
+                ) {
+                    return visibleElements.toMutableList()
+                }
+
+                clearVisibleElementSnapshot()
+                return mutableListOf()
+            }
+        }
+
         try {
-            val rootElement = findAllVisibleElements(rootNode, 0, null, indexCounter)
-            rootElement?.let {
-                collectRootElements(it, elements)
+            for ((rootNode, layer) in rootCandidates) {
+                collectVisibleElements(rootNode, layer, null, elements, indexCounter)
             }
         } finally {
-            rootNode.recycle()
+            rootCandidates.forEach { (node, _) -> node.recycle() }
         }
 
         synchronized(visibleElements) {
-            clearElementList()
+            clearVisibleElementSnapshot()
             visibleElements.addAll(elements)
+            visibleElementsSnapshotTimeMs = SystemClock.elapsedRealtime()
+            visibleElementsSnapshotPackageName = currentPackageName
+            visibleElementsSnapshotActivityName = currentActivityName
         }
 
         return elements
     }
 
-    private fun collectRootElements(element: ElementNode, rootElements: MutableList<ElementNode>) {
-        rootElements.add(element)
+    private fun collectRootCandidates(): List<Pair<AccessibilityNodeInfo, Int>> {
+        rootInActiveWindow?.let { return listOf(it to 0) }
+
+        val windows = windows ?: return emptyList()
+        val out = mutableListOf<Pair<AccessibilityNodeInfo, Int>>()
+        try {
+            windows.sortedByDescending { it.layer }
+                .filter { isUserFacingWindow(it) }
+                .forEach { window ->
+                    val root = window.root
+                    if (root != null) {
+                        out.add(root to window.layer)
+                    }
+                }
+        } finally {
+            windows.forEach { it.recycle() }
+        }
+        return out
     }
 
-    private fun findAllVisibleElements(
+    private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
+        return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
+                window.type == AccessibilityWindowInfo.TYPE_SYSTEM
+    }
+
+    private fun collectVisibleElements(
         node: AccessibilityNodeInfo,
         windowLayer: Int,
         parent: ElementNode?,
+        rootElements: MutableList<ElementNode>,
         indexCounter: IndexCounter
-    ): ElementNode? {
+    ) {
         try {
 
             val rect = Rect()
@@ -644,20 +714,6 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
                     else -> className.substringAfterLast('.')
                 }
 
-                val elementType = if (node.isClickable) {
-                    "Clickable"
-                } else if (node.isCheckable) {
-                    "Checkable"
-                } else if (node.isEditable) {
-                    "Input"
-                } else if (text.isNotEmpty()) {
-                    "Text"
-                } else if (node.isScrollable) {
-                    "Container"
-                } else {
-                    "View"
-                }
-
                 val id = ElementNode.createId(rect, className.substringAfterLast('.'), displayText)
 
                 val nodeCopy = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -679,25 +735,32 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
                 // Assign unique index
                 currentElement.overlayIndex = indexCounter.getNext()
 
-                // Set parent-child relationship
-                parent?.addChild(currentElement)
+                if (parent != null) {
+                    parent.addChild(currentElement)
+                } else {
+                    rootElements.add(currentElement)
+                }
             }
 
             // Recursively process children
+            val childParent = currentElement ?: parent
             for (i in 0 until node.childCount) {
                 val childNode = node.getChild(i) ?: continue
                 try {
-                    findAllVisibleElements(childNode, windowLayer, currentElement, indexCounter)
+                    collectVisibleElements(
+                        childNode,
+                        windowLayer,
+                        childParent,
+                        rootElements,
+                        indexCounter
+                    )
                 } finally {
                     childNode.recycle()
                 }
             }
 
-            return currentElement
-
         } catch (e: Exception) {
-            Log.e(TAG, "Error in findAllVisibleElements: ${e.message}", e)
-            return null
+            Log.e(TAG, "Error in collectVisibleElements: ${e.message}", e)
         }
     }
 
@@ -1399,7 +1462,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         stopWebSocketServer()
         hideLocalWebSocketConnectionNotification()
 
-        clearElementList()
+        clearVisibleElementSnapshot()
         configManager.removeListener(this)
         instance = null
         Log.d(TAG, "Accessibility service destroyed")

--- a/app/src/main/res/xml/accessibility_service_config.xml
+++ b/app/src/main/res/xml/accessibility_service_config.xml
@@ -3,10 +3,10 @@
     android:description="@string/accessibility_service_description"
     android:accessibilityEventTypes="typeWindowStateChanged|typeWindowContentChanged"
     android:accessibilityFeedbackType="feedbackGeneric"
-    android:accessibilityFlags="flagIncludeNotImportantViews|flagReportViewIds"
+    android:accessibilityFlags="flagIncludeNotImportantViews|flagReportViewIds|flagRetrieveInteractiveWindows"
     android:canRetrieveWindowContent="true"
     android:canTakeScreenshot="true"
     android:canPerformGestures="true"
     android:isAccessibilityTool="true"
     android:notificationTimeout="100"
-/> 
+/>

--- a/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
@@ -68,4 +68,69 @@ class StateRepositoryHeadlessTest {
             unmockkObject(AccessibilityTreeBuilder)
         }
     }
+
+    @Test
+    fun fullTreeFallbackPrefersApplicationRootOverHigherLayerSystemRoot() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val systemWindow = mockk<AccessibilityWindowInfo>()
+        val appWindow = mockk<AccessibilityWindowInfo>()
+        val systemRoot = mockk<AccessibilityNodeInfo>()
+        val appRoot = mockk<AccessibilityNodeInfo>()
+        val expected = JSONObject().put("app", true)
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(systemWindow, appWindow)
+        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
+        every { systemWindow.layer } returns 10
+        every { systemWindow.type } returns AccessibilityWindowInfo.TYPE_SYSTEM
+        every { systemWindow.root } returns systemRoot
+        every { systemWindow.recycle() } just runs
+        every { appWindow.layer } returns 1
+        every { appWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
+        every { appWindow.root } returns appRoot
+        every { appWindow.recycle() } just runs
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(appRoot, any())
+            } returns expected
+
+            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+
+            verify { appWindow.root }
+            verify(exactly = 0) { systemWindow.root }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
+
+    @Test
+    fun fullTreeFallbackUsesSystemRootWhenNoApplicationRootExists() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val systemWindow = mockk<AccessibilityWindowInfo>()
+        val systemRoot = mockk<AccessibilityNodeInfo>()
+        val expected = JSONObject().put("system", true)
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(systemWindow)
+        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
+        every { systemWindow.layer } returns 1
+        every { systemWindow.type } returns AccessibilityWindowInfo.TYPE_SYSTEM
+        every { systemWindow.root } returns systemRoot
+        every { systemWindow.recycle() } just runs
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(systemRoot, any())
+            } returns expected
+
+            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+
+            verify { systemWindow.root }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
 }

--- a/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
@@ -1,9 +1,22 @@
 package com.mobilerun.portal.core
 
+import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.mobilerun.portal.service.MobilerunAccessibilityService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.json.JSONObject
 
 class StateRepositoryHeadlessTest {
     @Test
@@ -19,5 +32,40 @@ class StateRepositoryHeadlessTest {
         assertNull(phoneState.packageName)
         assertFalse(phoneState.keyboardVisible)
         assertTrue(repository.takeScreenshot(hideOverlay = false).isCompletedExceptionally)
+    }
+
+    @Test
+    fun fullTreeFallbackSkipsUserFacingWindowsWithNullRoots() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val emptyTopWindow = mockk<AccessibilityWindowInfo>()
+        val appWindow = mockk<AccessibilityWindowInfo>()
+        val root = mockk<AccessibilityNodeInfo>()
+        val expected = JSONObject().put("ok", true)
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(emptyTopWindow, appWindow)
+        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
+        every { emptyTopWindow.layer } returns 2
+        every { emptyTopWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
+        every { emptyTopWindow.root } returns null
+        every { emptyTopWindow.recycle() } just runs
+        every { appWindow.layer } returns 1
+        every { appWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
+        every { appWindow.root } returns root
+        every { appWindow.recycle() } just runs
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root, any())
+            } returns expected
+
+            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+
+            verify { emptyTopWindow.root }
+            verify { appWindow.root }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
     }
 }

--- a/app/src/test/java/com/mobilerun/portal/service/MobilerunAccessibilityServiceTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/MobilerunAccessibilityServiceTest.kt
@@ -1,9 +1,81 @@
 package com.mobilerun.portal.service
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MobilerunAccessibilityServiceTest {
+
+    @Test
+    fun shouldReuseVisibleElementsSnapshot_allowsFreshSameScreenCache() {
+        val result = MobilerunAccessibilityService.shouldReuseVisibleElementsSnapshot(
+            cachedElementCount = 1,
+            snapshotTimeMs = 1_000L,
+            nowMs = 1_000L + MobilerunAccessibilityService.VISIBLE_ELEMENTS_STALE_GRACE_MS,
+            snapshotPackageName = "com.example.app",
+            currentPackageName = "com.example.app",
+            snapshotActivityName = "MainActivity",
+            currentActivityName = "MainActivity",
+        )
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun shouldReuseVisibleElementsSnapshot_rejectsExpiredCache() {
+        val result = MobilerunAccessibilityService.shouldReuseVisibleElementsSnapshot(
+            cachedElementCount = 1,
+            snapshotTimeMs = 1_000L,
+            nowMs = 1_001L + MobilerunAccessibilityService.VISIBLE_ELEMENTS_STALE_GRACE_MS,
+            snapshotPackageName = "com.example.app",
+            currentPackageName = "com.example.app",
+            snapshotActivityName = "MainActivity",
+            currentActivityName = "MainActivity",
+        )
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun shouldReuseVisibleElementsSnapshot_rejectsPackageOrActivityMismatch() {
+        val packageMismatch = MobilerunAccessibilityService.shouldReuseVisibleElementsSnapshot(
+            cachedElementCount = 1,
+            snapshotTimeMs = 1_000L,
+            nowMs = 1_100L,
+            snapshotPackageName = "com.example.app",
+            currentPackageName = "com.example.other",
+            snapshotActivityName = "MainActivity",
+            currentActivityName = "MainActivity",
+        )
+        val activityMismatch = MobilerunAccessibilityService.shouldReuseVisibleElementsSnapshot(
+            cachedElementCount = 1,
+            snapshotTimeMs = 1_000L,
+            nowMs = 1_100L,
+            snapshotPackageName = "com.example.app",
+            currentPackageName = "com.example.app",
+            snapshotActivityName = "MainActivity",
+            currentActivityName = "OtherActivity",
+        )
+
+        assertFalse(packageMismatch)
+        assertFalse(activityMismatch)
+    }
+
+    @Test
+    fun shouldReuseVisibleElementsSnapshot_rejectsEmptyCache() {
+        val result = MobilerunAccessibilityService.shouldReuseVisibleElementsSnapshot(
+            cachedElementCount = 0,
+            snapshotTimeMs = 1_000L,
+            nowMs = 1_100L,
+            snapshotPackageName = "com.example.app",
+            currentPackageName = "com.example.app",
+            snapshotActivityName = "MainActivity",
+            currentActivityName = "MainActivity",
+        )
+
+        assertFalse(result)
+    }
 
     @Test
     fun testCalculateInputText_Replace() {


### PR DESCRIPTION
Add interactive-window fallback for accessibility tree collection, preserve valid child subtrees when roots are filtered, and bound visible-tree cache reuse to avoid stale elements.

Original PR: https://github.com/droidrun/mobilerun-portal/pull/110 