### PR TITLE
fix: point credits balance at /api/commerce/balance and harden error rendering

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/taskprompt/PortalCloudClient.kt
+++ b/app/src/main/java/com/mobilerun/portal/taskprompt/PortalCloudClient.kt
@@ -51,6 +51,7 @@ data class PortalBalanceInfo(
     val balance: Int,
     val usage: Int,
     val nextReset: String?,
+    val unlimited: Boolean = false,
 )
 
 data class PortalTaskStatusSuccess(
@@ -116,6 +117,7 @@ class PortalCloudClient(
         const val DEFAULT_EXECUTION_TIMEOUT = 1000
         internal const val LAUNCH_RECOVERY_WINDOW_MS = 8_000L
         internal const val LAUNCH_RECOVERY_RETRY_INTERVAL_MS = 1_000L
+        private const val MAX_PLAIN_ERROR_DETAIL_CHARS = 280
 
         private const val SUPPORTED_JOIN_PATH = "/v1/providers/personal/join"
         private val JSON_MEDIA_TYPE = "application/json; charset=utf-8".toMediaType()
@@ -467,7 +469,7 @@ class PortalCloudClient(
             authToken: String,
         ): Request {
             return Request.Builder()
-                .url("${cloudBaseUrl.trimEnd('/')}/api/billing/balance")
+                .url("${cloudBaseUrl.trimEnd('/')}/api/commerce/balance")
                 .addHeader("Authorization", "Bearer $authToken")
                 .get()
                 .build()
@@ -565,20 +567,35 @@ class PortalCloudClient(
             }
         }
 
-        private fun parseErrorDetail(body: String?): String? {
+        fun parseErrorDetail(body: String?): String? {
             if (body.isNullOrBlank()) return null
 
-            return try {
-                if (body.trim().startsWith("{")) {
-                    val json = JSONObject(body)
+            val trimmed = body.trim()
+            return if (trimmed.startsWith("{")) {
+                try {
+                    val json = JSONObject(trimmed)
                     listOf("detail", "message", "error", "title")
-                        .mapNotNull { key -> json.optString(key).takeIf { it.isNotBlank() } }
+                        .mapNotNull { key -> sanitizeErrorDetail(json.opt(key) as? String) }
                         .firstOrNull()
-                } else {
-                    body.trim()
+                } catch (_: Exception) {
+                    null
                 }
-            } catch (_: Exception) {
-                body.trim()
+            } else {
+                sanitizeErrorDetail(trimmed)
+            }
+        }
+
+        // Retired cloud endpoints fall through to the Next.js web app, which answers
+        // with a full HTML 404 page; markup, raw JSON, or anything page-sized must
+        // never surface as an error message — whether bare or wrapped in a JSON field.
+        private fun sanitizeErrorDetail(value: String?): String? {
+            val detail = value?.trim().orEmpty()
+            return detail.takeIf {
+                it.isNotBlank() &&
+                    !it.startsWith("<") &&
+                    !it.startsWith("{") &&
+                    !it.startsWith("[") &&
+                    it.length <= MAX_PLAIN_ERROR_DETAIL_CHARS
             }
         }
 
@@ -591,12 +608,16 @@ class PortalCloudClient(
         }
 
         fun parseBalanceInfo(body: String): PortalBalanceInfo? {
+            // Accepts both the commerce shape {"credits":{"remaining","used","unlimited"}}
+            // and the legacy flat {"balance","usage"} shape.
             return try {
                 val root = JSONObject(body)
+                val credits = root.optJSONObject("credits")
                 PortalBalanceInfo(
-                    balance = if (root.has("balance") && !root.isNull("balance")) root.optInt("balance") else 0,
-                    usage = if (root.has("usage") && !root.isNull("usage")) root.optInt("usage") else 0,
+                    balance = credits?.let { optInt(it, "remaining") } ?: optInt(root, "balance") ?: 0,
+                    usage = credits?.let { optInt(it, "used") } ?: optInt(root, "usage") ?: 0,
                     nextReset = firstNonBlankString(root, "nextReset", "next_reset_at"),
+                    unlimited = credits?.let { optBoolean(it, "unlimited") } ?: false,
                 )
             } catch (_: Exception) {
                 null
@@ -618,7 +639,15 @@ class PortalCloudClient(
 
         private fun optInt(json: JSONObject, vararg keys: String): Int? {
             return keys.firstNotNullOfOrNull { key ->
-                if (json.has(key) && !json.isNull(key)) json.optInt(key) else null
+                if (json.has(key) && !json.isNull(key)) {
+                    // optInt wraps values beyond Int range (e.g. JS MAX_SAFE_INTEGER
+                    // sentinels) into negative numbers; clamp instead.
+                    json.optLong(key)
+                        .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+                        .toInt()
+                } else {
+                    null
+                }
             }
         }
 

--- a/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
@@ -467,10 +467,14 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
 
         val info = state.info
         val balanceLine = info?.let {
-            getString(
-                R.string.credits_balance_line,
-                formatCreditsCount(info.balance),
-            )
+            if (info.unlimited) {
+                getString(R.string.credits_balance_unlimited)
+            } else {
+                getString(
+                    R.string.credits_balance_line,
+                    formatCreditsCount(info.balance),
+                )
+            }
         }?.takeIf { it.isNotBlank() }
         val usageLine = info?.let {
             getString(

--- a/app/src/main/java/com/mobilerun/portal/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/settings/SettingsActivity.kt
@@ -682,10 +682,14 @@ class SettingsActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener
         val creditsState = PortalBalanceRepository.snapshot(currentCreditsFingerprint(authToken, cloudBaseUrl))
         val info = if (cloudBaseUrl != null) creditsState.info else null
         val balanceLine = info?.let {
-            getString(
-                com.mobilerun.portal.R.string.credits_balance_line,
-                formatCreditsCount(info.balance),
-            )
+            if (info.unlimited) {
+                getString(com.mobilerun.portal.R.string.credits_balance_unlimited)
+            } else {
+                getString(
+                    com.mobilerun.portal.R.string.credits_balance_line,
+                    formatCreditsCount(info.balance),
+                )
+            }
         }?.takeIf { it.isNotBlank() }
         val usageLine = info?.let {
             getString(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -289,6 +289,7 @@
     <string name="credits_card_subtitle">Track the credits available on this account.</string>
     <string name="credits_refresh_action">Refresh</string>
     <string name="credits_balance_line">%1$s credits remaining</string>
+    <string name="credits_balance_unlimited">Unlimited credits</string>
     <string name="credits_usage_line">%1$s credits used</string>
     <string name="credits_no_reset_scheduled">No reset scheduled</string>
     <string name="credits_loading">Loading credits…</string>

--- a/app/src/test/java/com/mobilerun/portal/taskprompt/PortalCloudClientTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/taskprompt/PortalCloudClientTest.kt
@@ -441,7 +441,7 @@ class PortalCloudClientTest {
             authToken = "token-abc",
         )
 
-        assertEquals("https://cloud.mobilerun.ai/api/billing/balance", request.url.toString())
+        assertEquals("https://cloud.mobilerun.ai/api/commerce/balance", request.url.toString())
         assertEquals("Bearer token-abc", request.header("Authorization"))
     }
 
@@ -577,6 +577,53 @@ class PortalCloudClientTest {
     }
 
     @Test
+    fun parseBalanceInfo_readsCommerceCreditsShape() {
+        val body = """
+            {
+              "credits": { "included": 500, "used": 60, "remaining": 440, "unlimited": false },
+              "topUpCredits": null,
+              "devices": []
+            }
+        """.trimIndent()
+
+        val result = PortalCloudClient.parseBalanceInfo(body)
+
+        requireNotNull(result)
+        assertEquals(440, result.balance)
+        assertEquals(60, result.usage)
+        assertNull(result.nextReset)
+        assertFalse(result.unlimited)
+    }
+
+    @Test
+    fun parseBalanceInfo_flagsUnlimitedAccounts() {
+        val body = """
+            {
+              "credits": { "included": 0, "used": 12, "remaining": null, "unlimited": true },
+              "topUpCredits": null,
+              "devices": []
+            }
+        """.trimIndent()
+
+        val result = PortalCloudClient.parseBalanceInfo(body)
+
+        requireNotNull(result)
+        assertTrue(result.unlimited)
+        assertEquals(0, result.balance)
+        assertEquals(12, result.usage)
+    }
+
+    @Test
+    fun parseBalanceInfo_clampsCountsBeyondIntRange() {
+        val body = """{ "credits": { "used": 0, "remaining": 9007199254740991, "unlimited": false } }"""
+
+        val result = PortalCloudClient.parseBalanceInfo(body)
+
+        requireNotNull(result)
+        assertEquals(Int.MAX_VALUE, result.balance)
+    }
+
+    @Test
     fun parseBalanceInfo_readsBalanceUsageAndNextReset() {
         val body = """
             {
@@ -626,6 +673,59 @@ class PortalCloudClientTest {
 
         requireNotNull(result)
         assertNull(result.nextReset)
+    }
+
+    @Test
+    fun parseErrorDetail_suppressesHtmlBodies() {
+        val body = """<!DOCTYPE html><html lang="en"><head><script src="/_next/static/chunks/webpack.js"></script></head><body>404</body></html>"""
+
+        assertNull(PortalCloudClient.parseErrorDetail(body))
+    }
+
+    @Test
+    fun parseErrorDetail_suppressesPageSizedPlainText() {
+        val body = "x".repeat(2_000)
+
+        assertNull(PortalCloudClient.parseErrorDetail(body))
+    }
+
+    @Test
+    fun parseErrorDetail_keepsShortPlainTextBodies() {
+        assertEquals("404 page not found", PortalCloudClient.parseErrorDetail("404 page not found\n"))
+    }
+
+    @Test
+    fun parseErrorDetail_readsJsonErrorField() {
+        assertEquals("Unauthorized", PortalCloudClient.parseErrorDetail("""{"error":"Unauthorized"}"""))
+    }
+
+    @Test
+    fun parseErrorDetail_returnsNullForMalformedJson() {
+        assertNull(PortalCloudClient.parseErrorDetail("{"))
+    }
+
+    @Test
+    fun parseErrorDetail_suppressesHtmlWrappedInJson() {
+        assertNull(PortalCloudClient.parseErrorDetail("""{"message":"<html><body>Server error page</body></html>"}"""))
+    }
+
+    @Test
+    fun parseErrorDetail_suppressesPageSizedJsonDetail() {
+        assertNull(PortalCloudClient.parseErrorDetail("""{"message":"${"x".repeat(2_000)}"}"""))
+    }
+
+    @Test
+    fun parseErrorDetail_skipsNullAndNonStringJsonValues() {
+        assertEquals(
+            "Real error",
+            PortalCloudClient.parseErrorDetail("""{"detail":null,"message":"Real error"}"""),
+        )
+        assertNull(PortalCloudClient.parseErrorDetail("""{"error":{"code":404}}"""))
+    }
+
+    @Test
+    fun parseErrorDetail_suppressesJsonArrayBodies() {
+        assertNull(PortalCloudClient.parseErrorDetail("""["Invalid token"]"""))
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Billing > Credits card has been rendering a raw Next.js HTML document instead of the balance. Root cause: the cloud renamed `/api/billing/*` → `/api/commerce/*` (2026-06-03) and deleted the old route. The catch-all on cloud.mobilerun.ai forwards the retired path to the Next.js web app, which answers with its HTML 404 page — and `parseErrorDetail` passed that body verbatim into the card via `PortalBalanceResult.Unavailable`.

Verified live: `GET https://cloud.mobilerun.ai/api/billing/balance` → 404 `text/html`; `GET https://cloud.mobilerun.ai/api/commerce/balance` → 401 `application/json` unauthenticated, i.e. the working endpoint.

## Changes

- **Endpoint**: `buildBalanceRequest` now targets `/api/commerce/balance`; auth header unchanged.
- **Response shape**: the rename also changed the payload from flat `{balance, usage}` to `{credits: {included, used, remaining, unlimited}, topUpCredits, devices[]}`. `parseBalanceInfo` reads `credits.remaining`/`credits.used` and keeps the flat keys as fallback — a path-only fix would have silently shown 0 credits.
- **Unlimited plans**: `credits.unlimited` renders as "Unlimited credits" instead of "0 credits remaining" (MainActivity + SettingsActivity).
- **Error hardening**: `parseErrorDetail` never returns markup, raw JSON, or >280-char bodies — bare or wrapped in a JSON field. JSON values are accepted only if string-typed, which also prevents Android org.json from surfacing explicit nulls as the literal string "null" (device/JVM org.json divergence). Any future endpoint move now degrades to the friendly fallback messages instead of repainting HTML.
- **Overflow**: shared `optInt` clamps values beyond Int range (JS `MAX_SAFE_INTEGER` sentinels previously wrapped to -1).

Mirrors the same fix in the internal portal ([mobilerun-portal-internal#65](https://github.com/droidrun/mobilerun-portal-internal/pull/65)).

## Test plan

- [x] `:app:testDebugUnitTest` green — 46 tests in `PortalCloudClientTest` incl. 12 new cases (commerce shape, unlimited, clamping, HTML/JSON-wrapped/array/page-sized error bodies, null/non-string JSON values), `PortalBalanceRepositoryTest` untouched and green
- [ ] On device: Billing > Credits shows real numbers after Refresh (cached HTML message clears on force refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)