### PR TITLE
feat: device-side SMS gateway engine (inbox/outbox)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />
@@ -154,6 +156,17 @@
             android:exported="true">
             <intent-filter android:priority="999">
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
+        <!-- SMS gateway: sent/delivered PendingIntent results (explicit-component only). -->
+        <receiver
+            android:name=".sms.SmsResultReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.mobilerun.portal.SMS_SENT" />
+                <action android:name="com.mobilerun.portal.SMS_DELIVERED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/mobilerun/portal/config/ConfigManager.kt
+++ b/app/src/main/java/com/mobilerun/portal/config/ConfigManager.kt
@@ -40,6 +40,7 @@ class ConfigManager private constructor(private val context: Context) {
         private const val KEY_DEV_MODE_ENABLED = "dev_mode_enabled"
         private const val KEY_INSTALL_AUTO_ACCEPT_ENABLED = "install_auto_accept_enabled"
         private const val KEY_KEEP_SCREEN_AWAKE_ENABLED = "keep_screen_awake_enabled"
+        private const val KEY_SMS_GATEWAY_ENABLED = "sms_gateway_enabled"
         private const val KEY_KEEP_ALIVE_LAST_RECOVERY_AT_MS = "keep_alive_last_recovery_at_ms"
         private const val KEY_KEEP_ALIVE_LAST_RECOVERY_ATTEMPT_AT_MS =
             "keep_alive_last_recovery_attempt_at_ms"
@@ -347,6 +348,14 @@ class ConfigManager private constructor(private val context: Context) {
         get() = sharedPrefs.getBoolean(KEY_KEEP_SCREEN_AWAKE_ENABLED, false)
         set(value) {
             sharedPrefs.edit { putBoolean(KEY_KEEP_SCREEN_AWAKE_ENABLED, value) }
+        }
+
+    // Opt-in SMS gateway (inbox/outbox via numbers-api). Persisted so a boot
+    // reconcile can restart it.
+    var smsGatewayEnabled: Boolean
+        get() = sharedPrefs.getBoolean(KEY_SMS_GATEWAY_ENABLED, false)
+        set(value) {
+            sharedPrefs.edit { putBoolean(KEY_SMS_GATEWAY_ENABLED, value) }
         }
 
     var keepAliveLastRecoveryAtMs: Long
@@ -707,6 +716,7 @@ class ConfigManager private constructor(private val context: Context) {
         fun onWebSocketEnabledChanged(enabled: Boolean) {}
         fun onWebSocketPortChanged(port: Int) {}
         fun onKeepScreenAwakeEnabledChanged(enabled: Boolean) {}
+        fun onSmsGatewayEnabledChanged(enabled: Boolean) {}
 
         fun onProductionModeChanged(enabled: Boolean) {}
     }
@@ -775,6 +785,12 @@ class ConfigManager private constructor(private val context: Context) {
         if (keepScreenAwakeEnabled == enabled) return
         keepScreenAwakeEnabled = enabled
         listeners.forEach { it.onKeepScreenAwakeEnabledChanged(enabled) }
+    }
+
+    fun setSmsGatewayEnabledWithNotification(enabled: Boolean) {
+        if (smsGatewayEnabled == enabled) return
+        smsGatewayEnabled = enabled
+        listeners.forEach { it.onSmsGatewayEnabledChanged(enabled) }
     }
 
     fun clearKeepAliveRuntimeState() {

--- a/app/src/main/java/com/mobilerun/portal/sms/SimHelper.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SimHelper.kt
@@ -1,0 +1,59 @@
+package com.mobilerun.portal.sms
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.telephony.SmsManager
+import android.telephony.SubscriptionManager
+import androidx.core.content.ContextCompat
+
+/** SIM selection + inbound-SIM extraction, ported from the OSS app's SubscriptionsHelper. */
+object SimHelper {
+
+    private fun hasPhoneState(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) ==
+            PackageManager.PERMISSION_GRANTED
+
+    private fun subscriptionManager(context: Context): SubscriptionManager? =
+        ContextCompat.getSystemService(context, SubscriptionManager::class.java)
+
+    /** Resolve the SmsManager for a 1-based simNumber (null → OS default). */
+    @Suppress("DEPRECATION")
+    fun getSmsManager(context: Context, simNumber: Int?): SmsManager {
+        if (simNumber == null || !hasPhoneState(context)) {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                context.getSystemService(SmsManager::class.java)
+            } else {
+                SmsManager.getDefault()
+            }
+        }
+        val slot = simNumber - 1
+        val sub = subscriptionManager(context)?.activeSubscriptionInfoList?.firstOrNull { it.simSlotIndex == slot }
+            ?: throw IllegalStateException("SIM $simNumber not found")
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            context.getSystemService(SmsManager::class.java).createForSubscriptionId(sub.subscriptionId)
+        } else {
+            SmsManager.getSmsManagerForSubscriptionId(sub.subscriptionId)
+        }
+    }
+
+    /** Read the subscriptionId an inbound SMS arrived on, if available. */
+    fun extractSubscriptionId(context: Context, intent: Intent): Int? {
+        val direct = intent.getIntExtra("subscription", -1).takeIf { it >= 0 }
+            ?: intent.getIntExtra(SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX, -1).takeIf { it >= 0 }
+        if (direct != null) return direct
+        if (!hasPhoneState(context)) return null
+        val slot = intent.getIntExtra("android.telephony.extra.SLOT_INDEX", -1).takeIf { it >= 0 } ?: return null
+        return subscriptionManager(context)?.activeSubscriptionInfoList?.firstOrNull { it.simSlotIndex == slot }?.subscriptionId
+    }
+
+    /** 1-based simNumber for a subscriptionId, for inbound attribution. */
+    fun simNumberForSubscription(context: Context, subscriptionId: Int?): Int? {
+        if (subscriptionId == null || !hasPhoneState(context)) return null
+        val slot = subscriptionManager(context)?.activeSubscriptionInfoList
+            ?.firstOrNull { it.subscriptionId == subscriptionId }?.simSlotIndex ?: return null
+        return slot + 1
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsApiClient.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsApiClient.kt
@@ -1,0 +1,141 @@
+package com.mobilerun.portal.sms
+
+import android.content.Context
+import android.util.Log
+import com.mobilerun.portal.config.ConfigManager
+import com.mobilerun.portal.taskprompt.PortalCloudClient
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * Talks to numbers-api over plain HTTPS, authenticated with the platform cloud
+ * token (Traefik injects X-User-ID). Synchronous calls — invoked from the sync
+ * worker thread. Endpoint shapes track numbers-api SMS_GATEWAY_PORT_PLAN.md.
+ */
+class SmsApiClient(context: Context) {
+    private val config = ConfigManager.getInstance(context)
+    private val http = OkHttpClient.Builder()
+        .callTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    private fun baseUrl(): String? {
+        val rest = PortalCloudClient.deriveRestBaseUrl(config.reverseConnectionUrlOrDefault) ?: return null
+        return "$rest/numbers"
+    }
+
+    private fun authedBuilder(url: String): Request.Builder =
+        Request.Builder().url(url).addHeader("Authorization", "Bearer ${config.reverseConnectionToken}")
+
+    fun registerDevice(deviceId: String, name: String, simCards: JSONArray): Boolean {
+        val base = baseUrl() ?: return false
+        val body = JSONObject().put("deviceId", deviceId).put("name", name).put("simCards", simCards)
+        return execute(authedBuilder("$base/devices/sms").post(body.toString().toRequestBody(JSON)).build())
+    }
+
+    fun ping(deviceId: String, state: String): Boolean {
+        val base = baseUrl() ?: return false
+        val body = JSONObject().put("state", state)
+        return execute(authedBuilder("$base/devices/$deviceId/sms/ping").post(body.toString().toRequestBody(JSON)).build())
+    }
+
+    fun getPending(deviceId: String): List<PendingSend> {
+        val base = baseUrl() ?: return emptyList()
+        val req = authedBuilder("$base/devices/$deviceId/sms/pending?order=lifo").get().build()
+        return try {
+            http.newCall(req).execute().use { res ->
+                if (!res.isSuccessful) return emptyList()
+                parsePending(res.body?.string().orEmpty())
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "getPending failed", e)
+            emptyList()
+        }
+    }
+
+    fun reportStatus(deviceId: String, rows: List<SmsStore.OutboundRow>): Boolean {
+        if (rows.isEmpty()) return true
+        val base = baseUrl() ?: return false
+        val payload = JSONArray()
+        for (r in rows) {
+            payload.put(
+                JSONObject()
+                    .put("id", r.sendTaskId)
+                    .put("state", r.state)
+                    .put(
+                        "recipients",
+                        JSONArray().put(
+                            JSONObject().put("phoneNumber", r.phoneNumber).put("state", r.state)
+                                .apply { r.error?.let { put("error", it) } },
+                        ),
+                    ),
+            )
+        }
+        return execute(authedBuilder("$base/devices/$deviceId/sms/status").patch(payload.toString().toRequestBody(JSON)).build())
+    }
+
+    fun postInbound(deviceId: String, sms: InboundSms): Boolean {
+        val base = baseUrl() ?: return false
+        val body = JSONObject()
+            .put("messageId", sms.localId)
+            .put("sender", sms.sender)
+            .put("recipient", sms.recipient)
+            .put("text", sms.body)
+            .apply { sms.simNumber?.let { put("simNumber", it) } }
+            .put("receivedAt", sms.receivedAtMs)
+        return execute(authedBuilder("$base/devices/$deviceId/sms/inbound").post(body.toString().toRequestBody(JSON)).build())
+    }
+
+    private fun execute(req: Request): Boolean = try {
+        http.newCall(req).execute().use { it.isSuccessful }
+    } catch (e: Exception) {
+        Log.w(TAG, "request failed: ${req.url}", e)
+        false
+    }
+
+    private fun parsePending(body: String): List<PendingSend> {
+        if (body.isBlank()) return emptyList()
+        // Tolerate either a bare array or a { data: { items: [...] } } / { data: [...] } envelope.
+        val items: JSONArray = when {
+            body.trimStart().startsWith("[") -> JSONArray(body)
+            else -> {
+                val root = JSONObject(body)
+                val data = root.opt("data")
+                when (data) {
+                    is JSONArray -> data
+                    is JSONObject -> data.optJSONArray("items") ?: JSONArray()
+                    else -> root.optJSONArray("items") ?: JSONArray()
+                }
+            }
+        }
+        return buildList {
+            for (i in 0 until items.length()) {
+                val o = items.optJSONObject(i) ?: continue
+                val id = o.optString("id").ifBlank { o.optString("sendTaskId") }
+                if (id.isBlank()) continue
+                val text = o.optJSONObject("textMessage")?.optString("text")
+                    ?: o.optString("message")
+                val phones = o.optJSONArray("phoneNumbers") ?: JSONArray()
+                add(
+                    PendingSend(
+                        sendTaskId = id,
+                        text = text,
+                        phoneNumbers = (0 until phones.length()).map { phones.optString(it) }.filter { it.isNotBlank() },
+                        simNumber = o.optInt("simNumber").takeIf { o.has("simNumber") },
+                        withDeliveryReport = o.optBoolean("withDeliveryReport", false),
+                        validUntilMs = null,
+                    ),
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "SmsApiClient"
+        private val JSON = "application/json; charset=utf-8".toMediaType()
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsEngine.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsEngine.kt
@@ -1,0 +1,100 @@
+package com.mobilerun.portal.sms
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.telephony.SmsManager
+import android.telephony.SmsMessage
+import android.util.Log
+
+/**
+ * Sends SMS via SmsManager and decodes sent/delivered results — the device
+ * telephony mechanics, ported from the OSS SMS Gate app. State is persisted in
+ * [SmsStore]; the sync worker reports it to numbers-api.
+ */
+object SmsEngine {
+    private const val TAG = "SmsEngine"
+    const val ACTION_SENT = "com.mobilerun.portal.SMS_SENT"
+    const val ACTION_DELIVERED = "com.mobilerun.portal.SMS_DELIVERED"
+
+    /** Send one task's recipients. Dedups on sendTaskId — a sent task is never re-sent. */
+    fun send(context: Context, store: SmsStore, send: PendingSend) {
+        if (send.validUntilMs != null && send.validUntilMs < System.currentTimeMillis()) {
+            store.insertOutboundIfAbsent(send, send.phoneNumbers.firstOrNull() ?: "")
+            store.setOutboundState(send.sendTaskId, SmsState.FAILED, "TTL expired")
+            return
+        }
+        for (phone in send.phoneNumbers) {
+            val fresh = store.insertOutboundIfAbsent(send, phone)
+            val current = store.outboundState(send.sendTaskId)
+            // Already past PENDING (claimed/sent) → don't re-dispatch to the carrier.
+            if (!fresh && current != null && current != SmsState.PENDING.api) continue
+
+            try {
+                dispatch(context, store, send, phone)
+                store.setOutboundState(send.sendTaskId, SmsState.PROCESSED)
+            } catch (e: Exception) {
+                Log.e(TAG, "send failed for ${send.sendTaskId}", e)
+                store.setOutboundState(send.sendTaskId, SmsState.FAILED, e.message)
+            }
+        }
+    }
+
+    private fun dispatch(context: Context, store: SmsStore, send: PendingSend, phone: String) {
+        val smsManager = SimHelper.getSmsManager(context, send.simNumber)
+        val key = Uri.parse("${send.sendTaskId}|$phone")
+        val sentPi = broadcast(context, ACTION_SENT, key)
+        val deliveredPi = if (send.withDeliveryReport) broadcast(context, ACTION_DELIVERED, key) else null
+
+        val parts = smsManager.divideMessage(send.text)
+        store.setPartsCount(send.sendTaskId, parts.size)
+        if (parts.size > 1) {
+            // Same PendingIntent per part (the OSS app does the same); Android fires it once per part.
+            val sentList = ArrayList<PendingIntent>(parts.size).apply { repeat(parts.size) { add(sentPi) } }
+            val deliveredList = deliveredPi?.let { pi ->
+                ArrayList<PendingIntent>(parts.size).apply { repeat(parts.size) { add(pi) } }
+            }
+            smsManager.sendMultipartTextMessage(phone, null, parts, sentList, deliveredList)
+        } else {
+            smsManager.sendTextMessage(phone, null, send.text, sentPi, deliveredPi)
+        }
+    }
+
+    private fun broadcast(context: Context, action: String, data: Uri): PendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            0,
+            Intent(action, data, context, SmsResultReceiver::class.java),
+            PendingIntent.FLAG_MUTABLE,
+        )
+
+    /** Decode an ACTION_SENT / ACTION_DELIVERED broadcast and persist the new state. */
+    fun processResult(context: Context, intent: Intent, resultCode: Int) {
+        val sendTaskId = intent.dataString?.substringBefore('|') ?: return
+        val store = SmsStore.getInstance(context)
+        when (intent.action) {
+            ACTION_SENT -> if (resultCode == Activity.RESULT_OK) {
+                store.setOutboundState(sendTaskId, SmsState.SENT)
+            } else {
+                store.setOutboundState(sendTaskId, SmsState.FAILED, "send result $resultCode")
+            }
+
+            ACTION_DELIVERED -> {
+                if (resultCode != Activity.RESULT_OK) {
+                    store.setOutboundState(sendTaskId, SmsState.FAILED, "delivery result $resultCode")
+                    return
+                }
+                val pdu = intent.getByteArrayExtra("pdu") ?: return
+                @Suppress("DEPRECATION")
+                val status = SmsMessage.createFromPdu(pdu)?.status ?: return
+                when {
+                    status.toUInt() < 0x20u -> store.setOutboundState(sendTaskId, SmsState.DELIVERED)
+                    status.toUInt() < 0x40u -> Unit // 0x20–0x3F: SC still trying, ignore
+                    else -> store.setOutboundState(sendTaskId, SmsState.FAILED, "delivery status $status")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsGatewayController.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsGatewayController.kt
@@ -1,0 +1,147 @@
+package com.mobilerun.portal.sms
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.provider.Telephony
+import android.telephony.SubscriptionManager
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.mobilerun.portal.config.ConfigManager
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Opt-in coordinator for the SMS gateway: registers the device with numbers-api,
+ * runs a periodic sync (drain inbound → upload, pull outbound → send, report
+ * status), and registers/unregisters the inbound SMS receiver. No coroutines /
+ * WorkManager — a single-thread scheduled executor, matching the portal's style.
+ */
+object SmsGatewayController {
+    private const val TAG = "SmsGateway"
+    private const val SYNC_INTERVAL_SEC = 15L
+
+    private var appContext: Context? = null
+    private var executor: ScheduledExecutorService? = null
+    private var inboundReceiver: SmsInboundReceiver? = null
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        if (enabled) enable(context) else disable(context)
+    }
+
+    @Synchronized
+    fun enable(context: Context) {
+        val ctx = context.applicationContext
+        appContext = ctx
+        ConfigManager.getInstance(ctx).setSmsGatewayEnabledWithNotification(true)
+        registerInboundReceiver(ctx)
+        startExecutor(ctx)
+        poke(ctx) // immediate first cycle: register + initial pull/drain
+    }
+
+    @Synchronized
+    fun disable(context: Context) {
+        val ctx = context.applicationContext
+        ConfigManager.getInstance(ctx).setSmsGatewayEnabledWithNotification(false)
+        inboundReceiver?.let { runCatching { ctx.unregisterReceiver(it) } }
+        inboundReceiver = null
+        executor?.shutdownNow()
+        executor = null
+    }
+
+    /** Restart on boot/app-foreground if the feature was left enabled. */
+    @Synchronized
+    fun reconcile(context: Context) {
+        if (ConfigManager.getInstance(context).smsGatewayEnabled) enable(context)
+    }
+
+    /** Trigger an immediate sync cycle (e.g. after an inbound SMS). */
+    fun poke(context: Context) {
+        appContext = context.applicationContext
+        executor?.execute { runCycle() }
+    }
+
+    @Synchronized
+    private fun startExecutor(ctx: Context) {
+        if (executor != null) return
+        registerDevice(ctx)
+        executor = Executors.newSingleThreadScheduledExecutor().also {
+            it.scheduleWithFixedDelay({ runCycle() }, 0, SYNC_INTERVAL_SEC, TimeUnit.SECONDS)
+        }
+    }
+
+    private fun registerInboundReceiver(ctx: Context) {
+        if (inboundReceiver != null) return
+        val receiver = SmsInboundReceiver()
+        ctx.registerReceiver(receiver, IntentFilter(Telephony.Sms.Intents.SMS_RECEIVED_ACTION))
+        inboundReceiver = receiver
+    }
+
+    private fun registerDevice(ctx: Context) {
+        runCatching {
+            val config = ConfigManager.getInstance(ctx)
+            SmsApiClient(ctx).registerDevice(config.deviceID, android.os.Build.MODEL ?: "android", buildSimCards(ctx))
+        }.onFailure { Log.w(TAG, "registerDevice failed", it) }
+    }
+
+    private fun runCycle() {
+        val ctx = appContext ?: return
+        val config = ConfigManager.getInstance(ctx)
+        if (!config.smsGatewayEnabled) return
+
+        val deviceId = config.deviceID
+        val store = SmsStore.getInstance(ctx)
+        val client = SmsApiClient(ctx)
+
+        runCatching {
+            client.ping(deviceId, capabilityState(ctx))
+
+            // Inbox: upload received SMS, ack only after the cloud persists them.
+            for (sms in store.unackedInbound()) {
+                if (client.postInbound(deviceId, sms)) store.markInboundAcked(sms.localId)
+            }
+
+            // Outbox: pull queued sends and dispatch (dedup-safe in the engine).
+            for (send in client.getPending(deviceId)) {
+                SmsEngine.send(ctx, store, send)
+            }
+
+            // Report state changes; mark reported on success.
+            val unreported = store.unreportedOutbound()
+            if (unreported.isNotEmpty() && client.reportStatus(deviceId, unreported)) {
+                unreported.forEach { store.markReported(it.sendTaskId) }
+            }
+        }.onFailure { Log.w(TAG, "sync cycle failed", it) }
+    }
+
+    private fun capabilityState(ctx: Context): String {
+        val send = ContextCompat.checkSelfPermission(ctx, Manifest.permission.SEND_SMS) == PackageManager.PERMISSION_GRANTED
+        val receive = ContextCompat.checkSelfPermission(ctx, Manifest.permission.RECEIVE_SMS) == PackageManager.PERMISSION_GRANTED
+        return if (send && receive) "ready" else "permission_revoked"
+    }
+
+    private fun buildSimCards(ctx: Context): JSONArray {
+        val arr = JSONArray()
+        if (ContextCompat.checkSelfPermission(ctx, Manifest.permission.READ_PHONE_STATE) != PackageManager.PERMISSION_GRANTED) {
+            return arr
+        }
+        val sm = ContextCompat.getSystemService(ctx, SubscriptionManager::class.java) ?: return arr
+        @Suppress("MissingPermission")
+        sm.activeSubscriptionInfoList?.forEach { info ->
+            arr.put(
+                JSONObject()
+                    .put("slotIndex", info.simSlotIndex)
+                    .put("simNumber", info.simSlotIndex + 1)
+                    .put("subscriptionId", info.subscriptionId)
+                    .put("carrierName", info.carrierName?.toString())
+                    .apply { info.number?.takeIf { it.isNotBlank() }?.let { put("phoneNumber", it) } },
+            )
+        }
+        return arr
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsInboundReceiver.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsInboundReceiver.kt
@@ -1,0 +1,42 @@
+package com.mobilerun.portal.sms
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Telephony
+
+/**
+ * Captures incoming SMS, persists it durably, and pokes the sync worker to
+ * upload it to numbers-api. Registered dynamically by [SmsGatewayController]
+ * while the feature is enabled (parallel to the trigger engine's receiver).
+ */
+class SmsInboundReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
+        val messages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
+        if (messages.isNullOrEmpty()) return
+
+        val first = messages.first()
+        val body = messages.joinToString(separator = "") { it.messageBody.orEmpty() }
+        val sender = first.originatingAddress.orEmpty()
+        val receivedAt = first.timestampMillis
+        val subscriptionId = SimHelper.extractSubscriptionId(context, intent)
+        val simNumber = SimHelper.simNumberForSubscription(context, subscriptionId)
+
+        // Stable local id (dedups redelivered broadcasts) → also the cloud dedup key.
+        val localId = "rx:" + (sender + "|" + receivedAt + "|" + body).hashCode().toUInt().toString(16)
+
+        val stored = SmsStore.getInstance(context).insertInbound(
+            InboundSms(
+                localId = localId,
+                sender = sender,
+                recipient = null,
+                body = body,
+                simNumber = simNumber,
+                subscriptionId = subscriptionId,
+                receivedAtMs = receivedAt,
+            ),
+        )
+        if (stored) SmsGatewayController.poke(context.applicationContext)
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsModels.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsModels.kt
@@ -1,0 +1,34 @@
+package com.mobilerun.portal.sms
+
+/**
+ * SMS processing state, named to match the numbers-api / SMS Gate contract.
+ * Reported back to the cloud verbatim via PATCH .../sms/status.
+ */
+enum class SmsState(val api: String) {
+    PENDING("Pending"),
+    PROCESSED("Processed"),
+    SENT("Sent"),
+    DELIVERED("Delivered"),
+    FAILED("Failed"),
+}
+
+/** An outbound send task pulled from numbers-api. */
+data class PendingSend(
+    val sendTaskId: String,
+    val text: String,
+    val phoneNumbers: List<String>,
+    val simNumber: Int?,
+    val withDeliveryReport: Boolean,
+    val validUntilMs: Long?,
+)
+
+/** A received SMS captured on the device, queued for upload. */
+data class InboundSms(
+    val localId: String,
+    val sender: String,
+    val recipient: String?,
+    val body: String,
+    val simNumber: Int?,
+    val subscriptionId: Int?,
+    val receivedAtMs: Long,
+)

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsResultReceiver.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsResultReceiver.kt
@@ -1,0 +1,15 @@
+package com.mobilerun.portal.sms
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Receives the sent/delivered PendingIntent broadcasts fired by SmsManager.
+ * Declared statically in the manifest (explicit-component intents only).
+ */
+class SmsResultReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        SmsEngine.processResult(context.applicationContext, intent, resultCode)
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/sms/SmsStore.kt
+++ b/app/src/main/java/com/mobilerun/portal/sms/SmsStore.kt
@@ -1,0 +1,185 @@
+package com.mobilerun.portal.sms
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+
+/**
+ * Device-local durable store for the SMS engine — the reliability backbone.
+ *
+ * Outbound rows are written BEFORE calling SmsManager and deduped on
+ * sendTaskId so a task is never sent twice even if re-pulled. Sent/delivered
+ * receivers recover state from here, not memory. Inbound rows are persisted
+ * synchronously on receipt, then drained to numbers-api by the sync worker.
+ *
+ * Plain SQLite (no Room/coroutines) to match the portal's minimal stack.
+ */
+class SmsStore private constructor(context: Context) :
+    SQLiteOpenHelper(context.applicationContext, DB_NAME, null, DB_VERSION) {
+
+    companion object {
+        private const val DB_NAME = "mobilerun_sms.db"
+        private const val DB_VERSION = 1
+
+        @Volatile
+        private var INSTANCE: SmsStore? = null
+
+        fun getInstance(context: Context): SmsStore =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: SmsStore(context).also { INSTANCE = it }
+            }
+    }
+
+    override fun onCreate(db: SQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE outbound (
+                sendTaskId TEXT PRIMARY KEY,
+                phoneNumber TEXT NOT NULL,
+                body TEXT NOT NULL,
+                simNumber INTEGER,
+                withDeliveryReport INTEGER NOT NULL DEFAULT 0,
+                partsCount INTEGER NOT NULL DEFAULT 0,
+                state TEXT NOT NULL,
+                error TEXT,
+                reported INTEGER NOT NULL DEFAULT 0,
+                updatedAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            """
+            CREATE TABLE inbound (
+                localId TEXT PRIMARY KEY,
+                sender TEXT NOT NULL,
+                recipient TEXT,
+                body TEXT NOT NULL,
+                simNumber INTEGER,
+                subscriptionId INTEGER,
+                receivedAt INTEGER NOT NULL,
+                acked INTEGER NOT NULL DEFAULT 0
+            )
+            """.trimIndent(),
+        )
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
+        // v1 only; future migrations go here.
+    }
+
+    // ── Outbound ─────────────────────────────────────────────────────────
+
+    /** Insert a task if new. Returns false when the task already exists (dedup). */
+    fun insertOutboundIfAbsent(send: PendingSend, phoneNumber: String): Boolean {
+        val values = ContentValues().apply {
+            put("sendTaskId", send.sendTaskId)
+            put("phoneNumber", phoneNumber)
+            put("body", send.text)
+            send.simNumber?.let { put("simNumber", it) }
+            put("withDeliveryReport", if (send.withDeliveryReport) 1 else 0)
+            put("state", SmsState.PENDING.api)
+            put("reported", 0)
+            put("updatedAt", System.currentTimeMillis())
+        }
+        // CONFLICT_IGNORE → returns -1 when the row already exists.
+        return writableDatabase.insertWithOnConflict("outbound", null, values, SQLiteDatabase.CONFLICT_IGNORE) >= 0
+    }
+
+    fun setPartsCount(sendTaskId: String, parts: Int) =
+        updateOutbound(sendTaskId) { put("partsCount", parts) }
+
+    /** Advance state, marking it unreported so the worker pushes it to the cloud. */
+    fun setOutboundState(sendTaskId: String, state: SmsState, error: String? = null) {
+        updateOutbound(sendTaskId) {
+            put("state", state.api)
+            put("error", error)
+            put("reported", 0)
+        }
+    }
+
+    fun markReported(sendTaskId: String) = updateOutbound(sendTaskId) { put("reported", 1) }
+
+    fun outboundState(sendTaskId: String): String? =
+        readableDatabase.query("outbound", arrayOf("state"), "sendTaskId = ?", arrayOf(sendTaskId), null, null, null)
+            .use { if (it.moveToFirst()) it.getString(0) else null }
+
+    /** Rows whose state changed since the last successful report. */
+    fun unreportedOutbound(): List<OutboundRow> =
+        readableDatabase.query("outbound", null, "reported = 0", null, null, null, "updatedAt ASC").use { c ->
+            buildList {
+                while (c.moveToNext()) add(OutboundRow.from(c))
+            }
+        }
+
+    private inline fun updateOutbound(sendTaskId: String, block: ContentValues.() -> Unit) {
+        val values = ContentValues().apply { put("updatedAt", System.currentTimeMillis()); block() }
+        writableDatabase.update("outbound", values, "sendTaskId = ?", arrayOf(sendTaskId))
+    }
+
+    // ── Inbound ──────────────────────────────────────────────────────────
+
+    fun insertInbound(sms: InboundSms): Boolean {
+        val values = ContentValues().apply {
+            put("localId", sms.localId)
+            put("sender", sms.sender)
+            put("recipient", sms.recipient)
+            put("body", sms.body)
+            sms.simNumber?.let { put("simNumber", it) }
+            sms.subscriptionId?.let { put("subscriptionId", it) }
+            put("receivedAt", sms.receivedAtMs)
+            put("acked", 0)
+        }
+        return writableDatabase.insertWithOnConflict("inbound", null, values, SQLiteDatabase.CONFLICT_IGNORE) >= 0
+    }
+
+    fun unackedInbound(): List<InboundSms> =
+        readableDatabase.query("inbound", null, "acked = 0", null, null, null, "receivedAt ASC").use { c ->
+            buildList {
+                while (c.moveToNext()) {
+                    add(
+                        InboundSms(
+                            localId = c.getString(c.getColumnIndexOrThrow("localId")),
+                            sender = c.getString(c.getColumnIndexOrThrow("sender")),
+                            recipient = c.getStringOrNull("recipient"),
+                            body = c.getString(c.getColumnIndexOrThrow("body")),
+                            simNumber = c.getIntOrNull("simNumber"),
+                            subscriptionId = c.getIntOrNull("subscriptionId"),
+                            receivedAtMs = c.getLong(c.getColumnIndexOrThrow("receivedAt")),
+                        ),
+                    )
+                }
+            }
+        }
+
+    fun markInboundAcked(localId: String) {
+        val values = ContentValues().apply { put("acked", 1) }
+        writableDatabase.update("inbound", values, "localId = ?", arrayOf(localId))
+    }
+
+    data class OutboundRow(
+        val sendTaskId: String,
+        val phoneNumber: String,
+        val state: String,
+        val error: String?,
+    ) {
+        companion object {
+            fun from(c: android.database.Cursor) = OutboundRow(
+                sendTaskId = c.getString(c.getColumnIndexOrThrow("sendTaskId")),
+                phoneNumber = c.getString(c.getColumnIndexOrThrow("phoneNumber")),
+                state = c.getString(c.getColumnIndexOrThrow("state")),
+                error = c.getStringOrNull("error"),
+            )
+        }
+    }
+}
+
+private fun android.database.Cursor.getStringOrNull(col: String): String? {
+    val i = getColumnIndexOrThrow(col)
+    return if (isNull(i)) null else getString(i)
+}
+
+private fun android.database.Cursor.getIntOrNull(col: String): Int? {
+    val i = getColumnIndexOrThrow(col)
+    return if (isNull(i)) null else getInt(i)
+}


### PR DESCRIPTION
Device-side SMS engine connecting the portal to **numbers-api** over cloud-authed HTTPS — the inbox/outbox link from `docs/sms-gateway-integration-plan.md`. Telephony mechanics ported from the OSS SMS Gate app; custom MIT code in the portal's minimal style (platform SQLite + OkHttp + a scheduled executor — no Room/coroutines/WorkManager).

## What's here (`com.mobilerun.portal.sms`)
- **SmsStore** — durable SQLite queues; outbound deduped on `sendTaskId` (never double-send), inbound persisted until cloud-acked (no lost OTPs).
- **SmsEngine** + **SmsResultReceiver** — `SmsManager` multipart send, per-SIM selection, sent/delivered `PendingIntent` decode (PDU status bits), per-task state.
- **SmsInboundReceiver** — `SMS_RECEIVED` capture → durable store → upload.
- **SimHelper** — `subscriptionId`-based SIM selection + inbound SIM extraction.
- **SmsApiClient** — `register / pending / status / inbound / ping` against numbers-api, Bearer = existing cloud token, base via `PortalCloudClient.deriveRestBaseUrl`.
- **SmsGatewayController** — opt-in enable/disable, periodic sync cycle, receiver lifecycle.
- **ConfigManager**: persisted `smsGatewayEnabled` opt-in + listener. **Manifest**: `SEND_SMS`, `READ_PHONE_STATE`, the result receiver.

## Status
- ✅ Compiles (`compileDebugKotlin`, JDK 17 / SDK 34).
- ⛔ **Not yet wired to a settings/consent UI** — `SmsGatewayController.enable()` needs a toggle + permission request + consent screen (plan §9).
- ⛔ **Depends on numbers-api Phases 2–4** (register/pending/status/inbound) which aren't built yet — so no end-to-end run; field shapes must be locked against those endpoints.
- Boot reconcile (`SmsGatewayController.reconcile`) not yet hooked into a boot receiver / app start.

First cut for review against `docs/sms-gateway-integration-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)