### PR TITLE
fix: bound a11y reads + isolate socket acceptor so a wedged a11y binder can't hang the server (N3)

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/api/A11yReadGate.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/A11yReadGate.kt
@@ -1,0 +1,142 @@
+package com.mobilerun.portal.api
+
+import android.util.Log
+import org.json.JSONException
+import org.json.JSONObject
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Bounds accessibility-tree reads so a wedged a11y binder cannot hang the HTTP
+ * server. Each read is single-flight per cache key and runs on a small bounded
+ * pool of daemon workers with a hard [timeoutMs] budget; on timeout — or when
+ * every worker is busy — it returns the last good serialized snapshot marked
+ * `degraded`/`degradedReason`/`snapshotAgeMs` instead of blocking.
+ *
+ * A wedged read is not cancellable, so its worker is sacrificed, but it holds
+ * only one worker — a stuck key cannot stall reads of other keys, and the HTTP
+ * request workers stay free. Workers are reclaimed when idle, so an ApiHandler
+ * dropped without [close] does not leak them.
+ */
+class A11yReadGate(
+    private val nowMs: () -> Long = { System.currentTimeMillis() },
+    idleTimeoutMs: Long = IDLE_TIMEOUT_MS,
+    maxWorkers: Int = MAX_READ_WORKERS,
+) {
+    private data class Snapshot(val payload: String, val raw: Boolean, val tsMs: Long)
+
+    private val threadSeq = AtomicInteger()
+
+    // Bounded cached pool: reuse an idle worker, else spawn one (up to
+    // maxWorkers), else reject (all workers wedged). core=0 + SynchronousQueue
+    // means idle workers time out and are reclaimed — no leak.
+    private val executor = ThreadPoolExecutor(
+        0, maxWorkers,
+        idleTimeoutMs, TimeUnit.MILLISECONDS,
+        SynchronousQueue(),
+    ) { r -> Thread(r, "a11y-read-gate-${threadSeq.incrementAndGet()}").apply { isDaemon = true } }
+    private val cache = ConcurrentHashMap<String, Snapshot>()
+    private val inflight = ConcurrentHashMap<String, Future<ApiResponse>>()
+
+    /** Run [produce] (a blocking a11y read) with a hard [timeoutMs] budget. */
+    fun wrap(key: String, timeoutMs: Long, produce: () -> ApiResponse): ApiResponse {
+        val future = try {
+            inflight.compute(key) { _, existing ->
+                // Single-flight per key: reuse an in-flight read for this key
+                // instead of piling up duplicate work behind it.
+                if (existing != null && !existing.isDone) existing
+                // Cache inside the task so a read that completes AFTER the caller
+                // timed out still refreshes the snapshot. Per-key single-flight
+                // means at most one task per key, so no out-of-order overwrite.
+                else executor.submit(Callable { produce().also { cacheIfReadable(key, it) } })
+            }!!
+        } catch (e: RejectedExecutionException) {
+            // Every worker is busy/wedged (or the gate is shutting down): serve
+            // the last good snapshot rather than block a request worker.
+            return if (executor.isShutdown) ApiResponse.Error("accessibility read gate is shutting down")
+            else degradedFromCache(key, "a11y_saturated")
+        }
+        return try {
+            val result = future.get(timeoutMs, TimeUnit.MILLISECONDS)
+            inflight.remove(key, future)
+            result // already cached by the task on completion
+        } catch (e: TimeoutException) {
+            // Do NOT cancel — the binder call cannot be interrupted. Leave it on
+            // its worker and serve the last good snapshot, degraded.
+            degradedFromCache(key, "a11y_timeout")
+        } catch (e: ExecutionException) {
+            inflight.remove(key, future)
+            val cause = e.cause ?: e
+            Log.w(TAG, "accessibility read '$key' failed: ${cause.message}")
+            ApiResponse.Error(cause.message ?: "accessibility read failed")
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            ApiResponse.Error("accessibility read interrupted")
+        }
+    }
+
+    private fun cacheIfReadable(key: String, result: ApiResponse) {
+        when (result) {
+            is ApiResponse.Success -> (result.data as? String)?.let {
+                cache[key] = Snapshot(it, raw = false, tsMs = nowMs())
+            }
+            is ApiResponse.RawObject ->
+                cache[key] = Snapshot(result.json.toString(), raw = true, tsMs = nowMs())
+            // Only Success(String)/RawObject snapshots are cached; errors and
+            // other variants are not (a wrapped read never produces them).
+            else -> {}
+        }
+    }
+
+    private fun degradedFromCache(key: String, reason: String): ApiResponse {
+        val snap = cache[key]
+            ?: return ApiResponse.Error(
+                "accessibility read unavailable and no cached snapshot exists " +
+                    "(degraded; reason=$reason)"
+            )
+        val ageMs = nowMs() - snap.tsMs
+        return if (snap.raw) {
+            ApiResponse.RawObject(augmentObject(JSONObject(snap.payload), reason, ageMs))
+        } else {
+            ApiResponse.Success(augmentSerialized(snap.payload, reason, ageMs))
+        }
+    }
+
+    private fun augmentObject(obj: JSONObject, reason: String, ageMs: Long): JSONObject =
+        obj.put("degraded", true).put("degradedReason", reason).put("snapshotAgeMs", ageMs)
+
+    private fun augmentSerialized(serialized: String, reason: String, ageMs: Long): String =
+        try {
+            augmentObject(JSONObject(serialized), reason, ageMs).toString()
+        } catch (_: JSONException) {
+            // JSONArray payload (e.g. /a11y_tree): keep the client-visible shape
+            // (a bare array) rather than wrapping it.
+            serialized
+        }
+
+    fun close() {
+        executor.shutdownNow()
+    }
+
+    companion object {
+        private const val TAG = "A11yReadGate"
+
+        // Idle worker reclaim window: a dropped gate returns its threads instead
+        // of holding them for the whole process.
+        private const val IDLE_TIMEOUT_MS = 30_000L
+
+        // One worker per concurrently-read key. There are ~7 distinct read keys
+        // (a11y_tree, a11y_tree_full:filter=*, phone_state, state,
+        // state_full:filter=*), so 8 covers them with headroom; beyond that a
+        // read is served from the degraded cache rather than spawning unbounded.
+        private const val MAX_READ_WORKERS = 8
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -75,6 +75,7 @@ class ApiHandler(
         private const val ENABLE_UI_STOP_FALLBACK = true
         private const val FORCE_STOP_SCREEN_READY_TIMEOUT_MS = 5000L
         private const val ACCESSIBILITY_SERVICE_NOT_AVAILABLE = "Accessibility service not available"
+        private const val A11Y_READ_TIMEOUT_MS = 2_000L
         private const val EMPTY_TREE_MESSAGE =
             "Accessibility tree is empty: the service is connected but returned no UI " +
                 "nodes (no active window / root filtered out). Toggle Mobilerun " +
@@ -90,6 +91,14 @@ class ApiHandler(
 
     private val installLock = Any()
     private val fileOperations: FileOperations by lazy { FileOperations() }
+
+    // Bounds a11y reads so a wedged binder can't hang HTTP workers.
+    private val a11yReads = A11yReadGate()
+
+    /** Release the a11y read gate's dedicated thread. Call on service teardown. */
+    fun close() {
+        a11yReads.close()
+    }
     val applicationContext: Context
         get() = context.applicationContext
 
@@ -140,7 +149,14 @@ class ApiHandler(
         }
     }
 
-    fun getTree(): ApiResponse {
+    // The five accessibility reads below run through a11yReads.wrap so a wedged
+    // a11y binder times out (returning the last good snapshot, degraded) instead
+    // of hanging the HTTP worker. Filter is part of the cache key so filtered and
+    // unfiltered full-tree snapshots never cross-contaminate.
+    fun getTree(): ApiResponse =
+        a11yReads.wrap("a11y_tree", A11Y_READ_TIMEOUT_MS) { getTreeUncached() }
+
+    private fun getTreeUncached(): ApiResponse {
         requireAccessibilityService()?.let { return it }
         val elements = stateRepo.getVisibleElements()
         // Empty only signals a fault when there is also no active window/root
@@ -153,20 +169,29 @@ class ApiHandler(
         return ApiResponse.Success(JSONArray(json).toString())
     }
 
-    fun getTreeFull(filter: Boolean): ApiResponse {
+    fun getTreeFull(filter: Boolean): ApiResponse =
+        a11yReads.wrap("a11y_tree_full:filter=$filter", A11Y_READ_TIMEOUT_MS) { getTreeFullUncached(filter) }
+
+    private fun getTreeFullUncached(filter: Boolean): ApiResponse {
         requireAccessibilityService()?.let { return it }
         val tree = stateRepo.getFullTree(filter)
             ?: return ApiResponse.Error("No active window or root filtered out")
         return ApiResponse.Success(tree.toString())
     }
 
-    fun getPhoneState(): ApiResponse {
+    fun getPhoneState(): ApiResponse =
+        a11yReads.wrap("phone_state", A11Y_READ_TIMEOUT_MS) { getPhoneStateUncached() }
+
+    private fun getPhoneStateUncached(): ApiResponse {
         requireAccessibilityService()?.let { return it }
         val state = stateRepo.getPhoneState()
         return ApiResponse.Success(JsonBuilders.phoneStateToJson(state).toString())
     }
 
-    fun getState(): ApiResponse {
+    fun getState(): ApiResponse =
+        a11yReads.wrap("state", A11Y_READ_TIMEOUT_MS) { getStateUncached() }
+
+    private fun getStateUncached(): ApiResponse {
         requireAccessibilityService()?.let { return it }
         val elements = stateRepo.getVisibleElements()
         if (elements.isEmpty() && !stateRepo.hasActiveRoot()) {
@@ -182,7 +207,10 @@ class ApiHandler(
         return ApiResponse.Success(combined.toString())
     }
 
-    fun getStateFull(filter: Boolean): ApiResponse {
+    fun getStateFull(filter: Boolean): ApiResponse =
+        a11yReads.wrap("state_full:filter=$filter", A11Y_READ_TIMEOUT_MS) { getStateFullUncached(filter) }
+
+    private fun getStateFullUncached(filter: Boolean): ApiResponse {
         requireAccessibilityService()?.let { return it }
         val tree = stateRepo.getFullTree(filter)
             ?: return ApiResponse.Error("No active window or root filtered out")

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -55,6 +55,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         const val TAG = "MobilerunAccessibility"
         const val ACTION_DISABLE_LOCAL_WS_SERVER =
             "com.mobilerun.portal.action.DISABLE_LOCAL_WS_SERVER"
+        @Volatile
         private var instance: MobilerunAccessibilityService? = null
         private const val MIN_ELEMENT_SIZE = 5
         private const val TOAST_DEBOUNCE_MS = 60_000L
@@ -202,6 +203,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
     // TODO Make nullable
     private lateinit var actionDispatcher: ActionDispatcher
     private var socketServer: SocketServer? = null
+    private var apiHandler: ApiHandler? = null
     private var websocketServer: PortalWebSocketServer? = null
 
     // Periodic update state
@@ -246,6 +248,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
             this
         )
 
+        this.apiHandler = apiHandler
         actionDispatcher = ActionDispatcher(apiHandler)
         socketServer = SocketServer(apiHandler, configManager, actionDispatcher)
 
@@ -1585,6 +1588,17 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         hideLocalWebSocketConnectionNotification()
     }
 
+    override fun onUnbind(intent: android.content.Intent?): Boolean {
+        // The framework unbinds when the service is disabled/torn down. Drop the
+        // singleton so getInstance() can't hand callers a service whose a11y
+        // connection is gone, and release the read-gate thread. (Do NOT do this
+        // in onInterrupt — interrupt is not an unbind.)
+        Log.d(TAG, "Accessibility service unbound")
+        if (instance === this) instance = null
+        apiHandler?.close()
+        return super.onUnbind(intent)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         stopPeriodicUpdates()
@@ -1594,7 +1608,8 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
 
         clearVisibleElementSnapshot()
         configManager.removeListener(this)
-        instance = null
+        apiHandler?.close()
+        if (instance === this) instance = null
         Log.d(TAG, "Accessibility service destroyed")
     }
 

--- a/app/src/main/java/com/mobilerun/portal/service/SocketServer.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/SocketServer.kt
@@ -25,9 +25,16 @@ class SocketServer(
     companion object {
         private const val TAG = "MobilerunSocketServer"
         private const val DEFAULT_PORT = 8080
-        private const val THREAD_POOL_SIZE = 5
+        // Request handlers run on a bounded pool that is SEPARATE from the
+        // acceptor thread, so a few slow/wedged handlers can't starve accept()
+        // (which would otherwise let /ping die along with /state).
+        private const val HANDLER_POOL_SIZE = 8
+        private const val HANDLER_QUEUE_CAPACITY = 32
+        private const val CLIENT_SOCKET_TIMEOUT_MS = 15_000
+        private const val ACCEPT_TIMEOUT_MS = 1_000
         private const val HTTP_STATUS_OK = 200
         private const val HTTP_REASON_OK = "OK"
+        private const val HTTP_STATUS_SERVICE_UNAVAILABLE = 503
         private const val HTTP_STATUS_BAD_REQUEST = 400
         private const val HTTP_STATUS_UNAUTHORIZED = 401
         private const val AUTHORIZATION_HEADER_PREFIX = "Authorization:"
@@ -39,6 +46,7 @@ class SocketServer(
     private var serverSocket: ServerSocket? = null
     private var isRunning = AtomicBoolean(false)
     private var executorService: ExecutorService? = null
+    private var acceptorThread: Thread? = null
     private var port: Int = DEFAULT_PORT
 
     fun start(port: Int = DEFAULT_PORT): Boolean {
@@ -51,12 +59,24 @@ class SocketServer(
         Log.i(TAG, "Starting socket server on port $port...")
 
         return try {
-            executorService = Executors.newFixedThreadPool(THREAD_POOL_SIZE)
-            serverSocket = ServerSocket(port)
+            // Bounded handler pool: bounded queue + a CallerRuns-free reject so a
+            // request burst surfaces a 503 instead of growing an unbounded queue.
+            executorService = java.util.concurrent.ThreadPoolExecutor(
+                HANDLER_POOL_SIZE,
+                HANDLER_POOL_SIZE,
+                0L,
+                java.util.concurrent.TimeUnit.MILLISECONDS,
+                java.util.concurrent.ArrayBlockingQueue(HANDLER_QUEUE_CAPACITY),
+                java.util.concurrent.ThreadPoolExecutor.AbortPolicy(),
+            )
+            serverSocket = ServerSocket(port).apply { soTimeout = ACCEPT_TIMEOUT_MS }
             isRunning.set(true)
 
-            executorService?.submit {
-                acceptConnections()
+            // Accept on a DEDICATED thread, never on the handler pool, so handlers
+            // can never starve the acceptor.
+            acceptorThread = Thread({ acceptConnections() }, "socket-acceptor").apply {
+                isDaemon = true
+                start()
             }
 
             Log.i(TAG, "Socket server started successfully on port $port")
@@ -64,7 +84,7 @@ class SocketServer(
         } catch (e: Exception) {
             Log.e(TAG, "Failed to start socket server on port $port", e)
             isRunning.set(false)
-            executorService?.shutdown()
+            executorService?.shutdownNow()
             executorService = null
             false
         }
@@ -77,7 +97,9 @@ class SocketServer(
 
         try {
             serverSocket?.close()
-            executorService?.shutdown()
+            acceptorThread?.interrupt()
+            acceptorThread = null
+            executorService?.shutdownNow()
             executorService = null
             Log.i(TAG, "Socket server stopped")
         } catch (e: Exception) {
@@ -91,9 +113,28 @@ class SocketServer(
     private fun acceptConnections() {
         while (isRunning.get()) {
             try {
-                val clientSocket = serverSocket?.accept() ?: break
-                executorService?.submit {
-                    handleClient(clientSocket)
+                val clientSocket = try {
+                    serverSocket?.accept() ?: break
+                } catch (e: java.net.SocketTimeoutException) {
+                    continue // periodic wake to re-check isRunning
+                }
+                // Bound per-request reads so a stuck client/handler can't own a
+                // worker forever.
+                try { clientSocket.soTimeout = CLIENT_SOCKET_TIMEOUT_MS } catch (_: Exception) {}
+                try {
+                    executorService?.submit { handleClient(clientSocket) }
+                } catch (e: java.util.concurrent.RejectedExecutionException) {
+                    // Pool + queue full: fail fast with 503 instead of blocking.
+                    Log.w(TAG, "handler pool saturated; rejecting request with 503")
+                    try {
+                        sendErrorResponse(
+                            clientSocket.getOutputStream(),
+                            HTTP_STATUS_SERVICE_UNAVAILABLE,
+                            "Server busy",
+                        )
+                    } catch (_: Exception) {} finally {
+                        try { clientSocket.close() } catch (_: Exception) {}
+                    }
                 }
             } catch (e: SocketException) {
                 if (isRunning.get()) {

--- a/app/src/test/java/com/mobilerun/portal/api/A11yReadGateTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/A11yReadGateTest.kt
@@ -1,0 +1,221 @@
+package com.mobilerun.portal.api
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+class A11yReadGateTest {
+    @Before
+    fun setUp() {
+        mockkStatic(android.util.Log::class)
+        every { android.util.Log.w(any<String>(), any<String>()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun success_returns_and_caches() {
+        val gate = A11yReadGate()
+        val r = gate.wrap("k", 1000) { ApiResponse.Success(JSONObject().put("a", 1).toString()) }
+        assertTrue(r is ApiResponse.Success)
+        gate.close()
+    }
+
+    @Test
+    fun timeout_returns_cached_object_with_degraded_markers() {
+        val now = AtomicLong(1_000L)
+        val gate = A11yReadGate(nowMs = { now.get() })
+        // warm the cache with a good object payload
+        val warm = gate.wrap("state", 1000) {
+            ApiResponse.Success(JSONObject().put("a11y_tree", "[]").put("phone_state", JSONObject()).toString())
+        }
+        assertTrue(warm is ApiResponse.Success)
+
+        // now the read blocks; advance the clock so snapshotAgeMs is observable
+        now.set(1_500L)
+        val release = CountDownLatch(1)
+        val r = gate.wrap("state", 50) { release.await(); ApiResponse.Success("late") }
+        assertTrue("expected Success", r is ApiResponse.Success)
+        val obj = JSONObject((r as ApiResponse.Success).data as String)
+        assertTrue("a11y_tree preserved", obj.has("a11y_tree"))
+        assertTrue("phone_state preserved", obj.has("phone_state"))
+        assertEquals(true, obj.getBoolean("degraded"))
+        assertEquals("a11y_timeout", obj.getString("degradedReason"))
+        assertEquals(500L, obj.getLong("snapshotAgeMs"))
+        release.countDown()
+        gate.close()
+    }
+
+    @Test
+    fun cold_timeout_with_no_cache_returns_error() {
+        val gate = A11yReadGate()
+        val release = CountDownLatch(1)
+        val r = gate.wrap("cold", 50) { release.await(); ApiResponse.Success("x") }
+        assertTrue("expected Error", r is ApiResponse.Error)
+        assertTrue((r as ApiResponse.Error).message.lowercase().contains("degraded"))
+        release.countDown()
+        gate.close()
+    }
+
+    @Test
+    fun single_flight_does_not_pile_up_invocations() {
+        val gate = A11yReadGate()
+        val invocations = AtomicInteger(0)
+        val release = CountDownLatch(1)
+        val started = CountDownLatch(1)
+        val produce = {
+            invocations.incrementAndGet(); started.countDown(); release.await()
+            ApiResponse.Success("done")
+        }
+        val t1 = Thread { gate.wrap("state", 100, produce) }
+        t1.start()
+        started.await() // ensure the first read is in flight
+        // second concurrent call must reuse the in-flight read, not submit a new one
+        val r2 = gate.wrap("state", 100, produce)
+        assertTrue(r2 is ApiResponse.Error || r2 is ApiResponse.Success) // degraded/cold either way
+        assertEquals("produce must run once under single-flight", 1, invocations.get())
+        release.countDown(); t1.join(2000)
+        gate.close()
+    }
+
+    @Test
+    fun late_completion_after_timeout_is_cached_for_next_caller() {
+        // A read that exceeds the budget but completes shortly after must still
+        // populate the cache. The second read also times out, so it is forced
+        // onto the cache path and only succeeds if the late completion cached.
+        val gate = A11yReadGate()
+        val firstPayload = JSONObject().put("v", "FRESH").toString()
+
+        // First read blocks past the budget: caller times out with a COLD cache.
+        val release = CountDownLatch(1)
+        val first = gate.wrap("state", 50) { release.await(); ApiResponse.Success(firstPayload) }
+        assertTrue("cold cache -> error", first is ApiResponse.Error)
+
+        // The read then completes; the task must cache firstPayload.
+        release.countDown()
+        Thread.sleep(500) // single-thread executor finishes + caches
+
+        // A subsequent read also times out, so it is FORCED onto the cache path.
+        // It must serve the late-cached snapshot (FRESH), marked degraded —
+        // without the fix the cache would still be cold and this returns an error.
+        val release2 = CountDownLatch(1)
+        val r = gate.wrap("state", 50) { release2.await(); ApiResponse.Success("NEWER") }
+        assertTrue("expected cached Success, got $r", r is ApiResponse.Success)
+        val data = (r as ApiResponse.Success).data as String
+        assertTrue("must serve late-cached payload", data.contains("FRESH"))
+        assertTrue("served snapshot must be marked degraded", data.contains("degraded"))
+        release2.countDown()
+        gate.close()
+    }
+
+    @Test
+    fun raw_object_timeout_returns_degraded_raw_object() {
+        val now = AtomicLong(0L)
+        val gate = A11yReadGate(nowMs = { now.get() })
+        gate.wrap("state_full", 1000) { ApiResponse.RawObject(JSONObject().put("a11y_tree", JSONObject())) }
+        now.set(123L)
+        val release = CountDownLatch(1)
+        val r = gate.wrap("state_full", 50) { release.await(); ApiResponse.RawObject(JSONObject()) }
+        assertTrue("expected RawObject", r is ApiResponse.RawObject)
+        val obj = (r as ApiResponse.RawObject).json
+        assertEquals(true, obj.getBoolean("degraded"))
+        assertEquals(123L, obj.getLong("snapshotAgeMs"))
+        release.countDown()
+        gate.close()
+    }
+
+    @Test
+    fun idle_worker_thread_is_reclaimed_so_unclosed_owners_do_not_leak() {
+        // A gate dropped without close() must not leak its worker: the idle
+        // thread is reclaimed by the core-thread timeout. Capture this gate's
+        // exact worker thread (not a global name scan) and assert it dies idle.
+        val worker = AtomicReference<Thread>()
+        val gate = A11yReadGate(idleTimeoutMs = 100)
+        gate.wrap("k", 1000) {
+            worker.set(Thread.currentThread())
+            ApiResponse.Success("x")
+        }
+        val t = worker.get()
+        assertTrue("the read must have run on the gate worker", t != null && t.name.startsWith("a11y-read-gate"))
+
+        val deadline = System.currentTimeMillis() + 3_000
+        while (t!!.isAlive && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+        }
+        assertFalse("idle worker thread must be reclaimed (no leak)", t!!.isAlive)
+        gate.close()
+    }
+
+    @Test
+    fun array_payload_timeout_returned_unchanged() {
+        val gate = A11yReadGate()
+        gate.wrap("a11y_tree", 1000) { ApiResponse.Success("[{\"x\":1}]") }
+        val release = CountDownLatch(1)
+        val r = gate.wrap("a11y_tree", 50) { release.await(); ApiResponse.Success("[]") }
+        assertTrue(r is ApiResponse.Success)
+        // bare JSON array payload is preserved as-is (no degraded wrapper that
+        // would change the client-visible shape)
+        assertEquals("[{\"x\":1}]", (r as ApiResponse.Success).data)
+        assertFalse((r.data as String).contains("degraded"))
+        release.countDown()
+        gate.close()
+    }
+
+    @Test
+    fun a_wedged_read_does_not_block_other_keys() {
+        // One key stuck in a binder call must not stall reads of other keys.
+        val gate = A11yReadGate()
+        val started = CountDownLatch(1)
+        val wedge = CountDownLatch(1)
+        val stuck = Thread { gate.wrap("state_full", 5_000) { started.countDown(); wedge.await(); ApiResponse.Success("x") } }
+        stuck.start()
+        assertTrue("wedged read must be running on a worker", started.await(2, TimeUnit.SECONDS))
+
+        val r = gate.wrap("phone_state", 1_000) { ApiResponse.Success(JSONObject().put("ok", 1).toString()) }
+        assertTrue("independent key must complete on its own worker, got $r", r is ApiResponse.Success)
+        assertFalse("a fresh read is not degraded", ((r as ApiResponse.Success).data as String).contains("degraded"))
+
+        wedge.countDown(); stuck.join(2_000)
+        gate.close()
+    }
+
+    @Test
+    fun saturation_serves_cached_degraded() {
+        // With every worker busy, a fresh read is served from the degraded cache
+        // (reason a11y_saturated) instead of blocking.
+        val gate = A11yReadGate(maxWorkers = 1)
+        gate.wrap("a", 1_000) { ApiResponse.Success(JSONObject().put("v", "A").toString()) } // warm cache
+
+        val started = CountDownLatch(1)
+        val wedge = CountDownLatch(1)
+        val stuck = Thread { gate.wrap("b", 5_000) { started.countDown(); wedge.await(); ApiResponse.Success("x") } }
+        stuck.start()
+        assertTrue("the single worker must be occupied", started.await(2, TimeUnit.SECONDS))
+
+        val r = gate.wrap("a", 1_000) { ApiResponse.Success(JSONObject().put("v", "A2").toString()) }
+        assertTrue("saturated read serves cache, got $r", r is ApiResponse.Success)
+        val data = (r as ApiResponse.Success).data as String
+        assertTrue("serves the cached snapshot", data.contains("\"v\":\"A\""))
+        assertTrue("marked degraded", data.contains("degraded"))
+        assertTrue("saturation reason", data.contains("a11y_saturated"))
+
+        wedge.countDown(); stuck.join(2_000)
+        gate.close()
+    }
+}


### PR DESCRIPTION
A wedged accessibility binder read could block the HTTP server indefinitely (recoverable only by reboot): `rootInActiveWindow`/`windows` are raw synchronous binder calls with no timeout, and the socket server ran the acceptor and all handlers on one small pool, so a few stuck `/state` reads starved even `/ping`.

- **`A11yReadGate`** runs the five read endpoints (`getTree`, `getTreeFull`, `getPhoneState`, `getState`, `getStateFull`) single-flight on a dedicated worker with a 2s budget. On timeout it returns the last good snapshot marked `degraded`/`degradedReason`/`snapshotAgeMs` (object payloads) or the bare array unchanged. The worker reclaims its thread when idle, so a handler dropped without `close()` doesn't leak it.
- **`SocketServer`** accepts on a dedicated thread and runs handlers on a bounded pool that returns `503` when saturated, with accept/client socket timeouts.
- **`MobilerunAccessibilityService`** publishes its instance `@Volatile` and closes the handler on unbind/destroy.

The underlying trigger (Android dropping the window-content connection) is platform-side; this makes the portal degrade gracefully instead of hanging. `disableSelf` is intentionally not used — it disables the service in Settings, requiring the user to re-grant it.

Unit tests cover the gate: success/cache, timeout→degraded, cold→error, single-flight, and idle-thread reclaim — plus the existing handler tests through the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)