### PR TITLE
Fix cloud reconnect sign-out visibility

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/ui/ConnectionCardUiPolicy.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/ConnectionCardUiPolicy.kt
@@ -1,0 +1,22 @@
+package com.mobilerun.portal.ui
+
+import com.mobilerun.portal.state.ConnectionState
+
+object ConnectionCardUiPolicy {
+    fun shouldShowSignOut(
+        state: ConnectionState,
+        hasCloudCredentials: Boolean,
+    ): Boolean {
+        if (!hasCloudCredentials) return false
+        return when (state) {
+            ConnectionState.CONNECTED,
+            ConnectionState.CONNECTING,
+            ConnectionState.RECONNECTING,
+            ConnectionState.UNAUTHORIZED,
+            ConnectionState.LIMIT_EXCEEDED,
+            ConnectionState.BAD_REQUEST,
+            ConnectionState.ERROR -> true
+            else -> false
+        }
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
@@ -243,6 +243,10 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
             disconnectService()
         }
 
+        binding.btnConnectingSignOut.setOnClickListener {
+            showSignOutConfirmation()
+        }
+
         binding.btnErrorPrimaryAction.setOnClickListener {
             if (shouldOfferBrowserReauth(ConnectionStateManager.getState())) {
                 openBrowserSignIn(forceFreshLogin = true)
@@ -1509,6 +1513,12 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
             (state == ConnectionState.BAD_REQUEST && isOfficialMobilerunCloudConnection())
     }
 
+    private fun hasCloudCredentials(): Boolean {
+        val configManager = ConfigManager.getInstance(this)
+        return configManager.reverseConnectionToken.isNotBlank() ||
+            configManager.reverseConnectionServiceKey.isNotBlank()
+    }
+
     private fun openBrowserSignIn(forceFreshLogin: Boolean) {
         val configManager = ConfigManager.getInstance(this)
         if (forceFreshLogin) {
@@ -1695,16 +1705,26 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
             binding.btnErrorPrimaryAction.text = getString(R.string.retry)
             binding.btnErrorUseApiKey.visibility = View.GONE
             binding.btnErrorCustomConnection.visibility = View.GONE
+            binding.btnSignOut.visibility = View.GONE
+            binding.btnConnectingSignOut.visibility = View.GONE
+            binding.btnErrorSignOut.visibility = View.GONE
+            val showSignOut = ConnectionCardUiPolicy.shouldShowSignOut(
+                state = state,
+                hasCloudCredentials = hasCloudCredentials(),
+            )
 
             when (state) {
                 ConnectionState.CONNECTED -> {
                     binding.layoutConnected.visibility = View.VISIBLE
+                    binding.btnSignOut.visibility = if (showSignOut) View.VISIBLE else View.GONE
                     binding.textDeviceId.text =
                         "Device ID: ${ConfigManager.getInstance(this).deviceID}"
                 }
 
                 ConnectionState.CONNECTING, ConnectionState.RECONNECTING -> {
                     binding.layoutConnecting.visibility = View.VISIBLE
+                    binding.btnConnectingSignOut.visibility =
+                        if (showSignOut) View.VISIBLE else View.GONE
                     if (state == ConnectionState.RECONNECTING) {
                         binding.textConnectingStatus.text = "Reconnecting..."
                         binding.textConnectingSubtitle.text =
@@ -1718,6 +1738,8 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
 
                 ConnectionState.UNAUTHORIZED -> {
                     binding.layoutError.visibility = View.VISIBLE
+                    binding.btnErrorSignOut.visibility =
+                        if (showSignOut) View.VISIBLE else View.GONE
                     binding.textErrorSubtitle.text =
                         getString(R.string.error_unauthorized_actionable)
                     binding.btnErrorPrimaryAction.text = getString(R.string.sign_in_with_browser)
@@ -1727,11 +1749,15 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
 
                 ConnectionState.LIMIT_EXCEEDED -> {
                     binding.layoutError.visibility = View.VISIBLE
+                    binding.btnErrorSignOut.visibility =
+                        if (showSignOut) View.VISIBLE else View.GONE
                     binding.textErrorSubtitle.text = getString(R.string.error_limit_exceeded)
                 }
 
                 ConnectionState.BAD_REQUEST -> {
                     binding.layoutError.visibility = View.VISIBLE
+                    binding.btnErrorSignOut.visibility =
+                        if (showSignOut) View.VISIBLE else View.GONE
                     if (isOfficialMobilerunCloudConnection()) {
                         binding.textErrorSubtitle.text =
                             getString(R.string.error_bad_request_actionable)
@@ -1745,6 +1771,8 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
 
                 ConnectionState.ERROR -> {
                     binding.layoutError.visibility = View.VISIBLE
+                    binding.btnErrorSignOut.visibility =
+                        if (showSignOut) View.VISIBLE else View.GONE
                     binding.textErrorSubtitle.text = getString(R.string.error_unknown)
                 }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -716,18 +716,45 @@
 
                             </LinearLayout>
 
-                            <com.google.android.material.button.MaterialButton
-                                android:id="@+id/btn_cancel_connection"
-                                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                            <LinearLayout
                                 android:layout_width="wrap_content"
-                                android:layout_height="36dp"
-                                android:paddingHorizontal="14dp"
-                                android:paddingVertical="0dp"
-                                android:text="Cancel"
-                                android:textColor="@color/text_white"
-                                android:textSize="12sp"
-                                app:strokeColor="@color/stroke_gray"
-                                app:cornerRadius="8dp" />
+                                android:layout_height="wrap_content"
+                                android:gravity="end"
+                                android:orientation="vertical">
+
+                                <com.google.android.material.button.MaterialButton
+                                    android:id="@+id/btn_cancel_connection"
+                                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="34dp"
+                                    android:minWidth="0dp"
+                                    android:minHeight="0dp"
+                                    android:paddingHorizontal="12dp"
+                                    android:paddingVertical="0dp"
+                                    android:text="Cancel"
+                                    android:textColor="@color/text_white"
+                                    android:textSize="11sp"
+                                    app:strokeColor="@color/stroke_gray"
+                                    app:cornerRadius="8dp" />
+
+                                <com.google.android.material.button.MaterialButton
+                                    android:id="@+id/btn_connecting_sign_out"
+                                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="34dp"
+                                    android:layout_marginTop="8dp"
+                                    android:minWidth="0dp"
+                                    android:minHeight="0dp"
+                                    android:paddingHorizontal="12dp"
+                                    android:paddingVertical="0dp"
+                                    android:text="@string/sign_out"
+                                    android:textColor="@color/text_white"
+                                    android:textSize="11sp"
+                                    android:visibility="gone"
+                                    app:strokeColor="@color/stroke_gray"
+                                    app:cornerRadius="8dp" />
+
+                            </LinearLayout>
 
                         </LinearLayout>
 

--- a/app/src/test/java/com/mobilerun/portal/ui/ConnectionCardUiPolicyTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/ui/ConnectionCardUiPolicyTest.kt
@@ -1,0 +1,66 @@
+package com.mobilerun.portal.ui
+
+import com.mobilerun.portal.state.ConnectionState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ConnectionCardUiPolicyTest {
+    @Test
+    fun connectionProgressStatesOfferSignOutWhenCloudCredentialsExist() {
+        listOf(
+            ConnectionState.CONNECTING,
+            ConnectionState.RECONNECTING,
+        ).forEach { state ->
+            assertTrue(
+                "$state should expose sign out",
+                ConnectionCardUiPolicy.shouldShowSignOut(
+                    state = state,
+                    hasCloudCredentials = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun connectedAndCloudErrorStatesOfferSignOutWhenCloudCredentialsExist() {
+        listOf(
+            ConnectionState.CONNECTED,
+            ConnectionState.UNAUTHORIZED,
+            ConnectionState.LIMIT_EXCEEDED,
+            ConnectionState.BAD_REQUEST,
+            ConnectionState.ERROR,
+        ).forEach { state ->
+            assertTrue(
+                "$state should expose sign out",
+                ConnectionCardUiPolicy.shouldShowSignOut(
+                    state = state,
+                    hasCloudCredentials = true,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun supportedStatesDoNotOfferSignOutWithoutCloudCredentials() {
+        ConnectionState.values().forEach { state ->
+            assertFalse(
+                "$state should hide sign out without credentials",
+                ConnectionCardUiPolicy.shouldShowSignOut(
+                    state = state,
+                    hasCloudCredentials = false,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun disconnectedDoesNotOfferSignOutEvenWithCloudCredentials() {
+        assertFalse(
+            ConnectionCardUiPolicy.shouldShowSignOut(
+                state = ConnectionState.DISCONNECTED,
+                hasCloudCredentials = true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Show Sign Out while cloud connection is stuck in connecting/reconnecting when saved credentials exist.
- Hide connected/error Sign Out actions when no cloud credentials are saved.
- Add a small UI policy test covering connection states and credential presence.

## Validation
- `./gradlew :app:testDebugUnitTest --console=plain`
- `./gradlew :app:assembleDebug --console=plain`

Internal only:
- `./gradlew :app:testDebugUnitTest :portal-daemon:test --console=plain`
- `./gradlew :app:assembleDebug :portal-daemon:dexJar --console=plain`