### PR TITLE
Fix switch on/off color contrast

### DIFF
--- a/app/src/main/res/color/mobilerun_switch_thumb_tint.xml
+++ b/app/src/main/res/color/mobilerun_switch_thumb_tint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_enabled="false"
+        android:color="@color/text_gray" />
+    <item android:color="@color/white" />
+</selector>

--- a/app/src/main/res/color/mobilerun_switch_track_tint.xml
+++ b/app/src/main/res/color/mobilerun_switch_track_tint.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_enabled="false"
+        android:color="@color/text_gray_dark" />
+    <item
+        android:state_checked="true"
+        android:color="@color/mobilerun_primary" />
+    <item android:color="@color/text_gray_light" />
+</selector>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -60,8 +60,9 @@
     </style>
 
     <style name="Widget.Mobilerun.Switch" parent="Widget.MaterialComponents.CompoundButton.Switch">
-        <item name="thumbTint">@color/mobilerun_primary</item>
-        <item name="trackTint">@color/mobilerun_primary_light</item>
+        <item name="useMaterialThemeColors">false</item>
+        <item name="thumbTint">@color/mobilerun_switch_thumb_tint</item>
+        <item name="trackTint">@color/mobilerun_switch_track_tint</item>
     </style>
 
     <style name="Widget.Mobilerun.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">

--- a/app/src/test/java/com/mobilerun/portal/ui/SwitchTintResourceTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/ui/SwitchTintResourceTest.kt
@@ -1,0 +1,64 @@
+package com.mobilerun.portal.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SwitchTintResourceTest {
+    private val resDir: File = locateResDir()
+
+    @Test
+    fun switchStyleUsesExplicitTintSelectors() {
+        val themes = resource("values/themes.xml").readText()
+
+        assertTrue(themes.contains("<item name=\"useMaterialThemeColors\">false</item>"))
+        assertTrue(themes.contains("<item name=\"thumbTint\">@color/mobilerun_switch_thumb_tint</item>"))
+        assertTrue(themes.contains("<item name=\"trackTint\">@color/mobilerun_switch_track_tint</item>"))
+    }
+
+    @Test
+    fun trackTintSeparatesCheckedAndUncheckedStates() {
+        val track = resource("color/mobilerun_switch_track_tint.xml").readText()
+
+        assertTrue(track.contains("android:state_enabled=\"false\""))
+        assertTrue(track.contains("android:color=\"@color/text_gray_dark\""))
+        assertTrue(track.contains("android:state_checked=\"true\""))
+        assertTrue(track.contains("android:color=\"@color/mobilerun_primary\""))
+        assertTrue(track.contains("android:color=\"@color/text_gray_light\""))
+
+        val checkedColor = colorValue("mobilerun_primary")
+        val uncheckedColor = colorValue("text_gray_light")
+        assertEquals("#0D9373", checkedColor)
+        assertEquals("#AAAAAA", uncheckedColor)
+        assertNotEquals(checkedColor, uncheckedColor)
+    }
+
+    @Test
+    fun thumbTintUsesWhiteWhenEnabledAndGrayWhenDisabled() {
+        val thumb = resource("color/mobilerun_switch_thumb_tint.xml").readText()
+
+        assertTrue(thumb.contains("android:state_enabled=\"false\""))
+        assertTrue(thumb.contains("android:color=\"@color/text_gray\""))
+        assertTrue(thumb.contains("android:color=\"@color/white\""))
+    }
+
+    private fun resource(path: String): File = File(resDir, path)
+
+    private fun colorValue(name: String): String {
+        val colors = resource("values/colors.xml").readText()
+        val regex = Regex("""<color\s+name="$name">([^<]+)</color>""")
+        return requireNotNull(regex.find(colors)) {
+            "Missing color resource: $name"
+        }.groupValues[1].uppercase()
+    }
+
+    private fun locateResDir(): File {
+        val start = File(System.getProperty("user.dir") ?: error("user.dir is unavailable"))
+            .absoluteFile
+        return generateSequence(start) { it.parentFile }
+            .map { File(it, "src/main/res") }
+            .first { File(it, "values/themes.xml").isFile }
+    }
+}


### PR DESCRIPTION
## Summary
- Add explicit checked/unchecked switch tint selectors so on/off states are visually distinct across devices.
- Disable Material auto theme switch colors for the portal switch style.
- Add a static resource test covering the switch style and tint mapping.

## Root cause
The app switch style used one thumb color and one track color for every state. On some phones/OEM renderers, the unchecked state could look too similar to the checked state.

## Validation
- `./gradlew :app:testDebugUnitTest --console=plain`
- `./gradlew :app:assembleDebug --console=plain`
- Emulator visual smoke on `emulator-5554`: Settings screen shows unchecked switches with a light neutral track and checked switches with a green track.

## QA Artifacts
- `/private/tmp/dro-2065-switch-qa/public-settings-switches.png`