### PR TITLE
fix: serialize non-finite accessibility ranges

### DIFF
--- a/app/src/androidTest/java/com/mobilerun/portal/core/AccessibilityTreeBuilderInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mobilerun/portal/core/AccessibilityTreeBuilderInstrumentedTest.kt
@@ -1,0 +1,74 @@
+package com.mobilerun.portal.core
+
+import android.app.UiAutomation
+import android.os.SystemClock
+import android.view.accessibility.AccessibilityNodeInfo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AccessibilityTreeBuilderInstrumentedTest {
+
+    @Test
+    fun buildFullAccessibilityTreeJson_serializesRealUnboundedRangeInfo() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiAutomation = instrumentation.uiAutomation
+
+        ActivityScenario.launch(UnboundedRangeFixtureActivity::class.java).use {
+            instrumentation.waitForIdleSync()
+
+            val node = waitForUnboundedRangeNode(uiAutomation)
+            val json = AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(node)
+
+            assertNotNull(json)
+            val rangeJson = JSONObject(json!!.toString()).getJSONObject("rangeInfo")
+            assertEquals(AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, rangeJson.getInt("type"))
+            assertTrue(rangeJson.isNull("min"))
+            assertTrue(rangeJson.isNull("max"))
+            assertEquals(0.0, rangeJson.getDouble("current"), 0.0)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun waitForUnboundedRangeNode(uiAutomation: UiAutomation): AccessibilityNodeInfo {
+        val deadline = SystemClock.uptimeMillis() + NODE_TIMEOUT_MS
+
+        do {
+            val root = uiAutomation.rootInActiveWindow
+            val candidates = root
+                ?.findAccessibilityNodeInfosByText(UnboundedRangeFixtureActivity.NODE_MARKER)
+                .orEmpty()
+            var match: AccessibilityNodeInfo? = null
+            candidates.forEach { candidate ->
+                val range = candidate.rangeInfo
+                if (
+                    match == null &&
+                    range?.min == Float.NEGATIVE_INFINITY &&
+                    range.max == Float.POSITIVE_INFINITY
+                ) {
+                    match = candidate
+                } else {
+                    candidate.recycle()
+                }
+            }
+            root?.recycle()
+
+            match?.let { return it }
+            SystemClock.sleep(NODE_POLL_INTERVAL_MS)
+        } while (SystemClock.uptimeMillis() < deadline)
+
+        throw AssertionError("Timed out waiting for a sealed accessibility node with an unbounded range")
+    }
+
+    private companion object {
+        const val NODE_TIMEOUT_MS = 5_000L
+        const val NODE_POLL_INTERVAL_MS = 50L
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".core.UnboundedRangeFixtureActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar" />
+    </application>
+
+</manifest>

--- a/app/src/debug/java/com/mobilerun/portal/core/UnboundedRangeFixtureActivity.kt
+++ b/app/src/debug/java/com/mobilerun/portal/core/UnboundedRangeFixtureActivity.kt
@@ -1,0 +1,51 @@
+package com.mobilerun.portal.core
+
+import android.app.Activity
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.view.accessibility.AccessibilityNodeInfo
+
+/**
+ * Minimal debug-only host for accessibility instrumentation fixtures.
+ */
+class UnboundedRangeFixtureActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(
+            UnboundedRangeView(this),
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+    }
+
+    @Suppress("DEPRECATION")
+    private class UnboundedRangeView(context: Context) : View(context) {
+        init {
+            importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+            isFocusable = true
+            isFocusableInTouchMode = true
+            contentDescription = NODE_MARKER
+        }
+
+        override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
+            super.onInitializeAccessibilityNodeInfo(info)
+            info.className = "android.widget.SeekBar"
+            info.text = NODE_MARKER
+            info.rangeInfo = AccessibilityNodeInfo.RangeInfo.obtain(
+                AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT,
+                Float.NEGATIVE_INFINITY,
+                Float.POSITIVE_INFINITY,
+                0f,
+            )
+        }
+    }
+
+    companion object {
+        const val NODE_MARKER = "mobilerun-unbounded-range-fixture"
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/core/AccessibilityTreeBuilder.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/AccessibilityTreeBuilder.kt
@@ -239,9 +239,9 @@ object AccessibilityTreeBuilder {
             node.rangeInfo?.let { range ->
                 put("rangeInfo", JSONObject().apply {
                     put("type", range.type)
-                    put("min", range.min.toDouble())
-                    put("max", range.max.toDouble())
-                    put("current", range.current.toDouble())
+                    put("min", jsonFiniteFloatOrNull(range.min))
+                    put("max", jsonFiniteFloatOrNull(range.max))
+                    put("current", jsonFiniteFloatOrNull(range.current))
                 })
             }
 
@@ -365,6 +365,10 @@ object AccessibilityTreeBuilder {
             AccessibilityTraversalGuard.leaveActivePath(node, activeNodePath)
             node.recycle()
         }
+    }
+
+    private fun jsonFiniteFloatOrNull(value: Float): Any {
+        return if (value.isFinite()) value.toDouble() else JSONObject.NULL
     }
 
     private fun getVisiblePercentage(rect: Rect, screenBounds: Rect): Float {

--- a/app/src/test/java/com/mobilerun/portal/core/AccessibilityTreeBuilderTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/AccessibilityTreeBuilderTest.kt
@@ -113,6 +113,48 @@ class AccessibilityTreeBuilderTest {
         verify(exactly = 1) { root.recycle() }
     }
 
+    @Test
+    fun buildFullAccessibilityTreeJson_mapsNonFiniteRangeValuesToJsonNull() {
+        val root = node("root")
+        val range = mockk<AccessibilityNodeInfo.RangeInfo>()
+        configureNode(root)
+        every { range.type } returns AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT
+        every { range.min } returns Float.NEGATIVE_INFINITY
+        every { range.max } returns Float.POSITIVE_INFINITY
+        every { range.current } returns Float.NaN
+        every { root.rangeInfo } returns range
+
+        val json = AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root)
+
+        assertNotNull(json)
+        val rangeJson = JSONObject(json!!.toString()).getJSONObject("rangeInfo")
+        assertEquals(AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, rangeJson.getInt("type"))
+        assertTrue(rangeJson.isNull("min"))
+        assertTrue(rangeJson.isNull("max"))
+        assertTrue(rangeJson.isNull("current"))
+    }
+
+    @Test
+    fun buildFullAccessibilityTreeJson_preservesFiniteRangeValues() {
+        val root = node("root")
+        val range = mockk<AccessibilityNodeInfo.RangeInfo>()
+        configureNode(root)
+        every { range.type } returns AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT
+        every { range.min } returns -10.5f
+        every { range.max } returns 42.25f
+        every { range.current } returns 7.5f
+        every { root.rangeInfo } returns range
+
+        val json = AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root)
+
+        assertNotNull(json)
+        val rangeJson = JSONObject(json!!.toString()).getJSONObject("rangeInfo")
+        assertEquals(AccessibilityNodeInfo.RangeInfo.RANGE_TYPE_FLOAT, rangeJson.getInt("type"))
+        assertEquals(-10.5, rangeJson.getDouble("min"), 0.0)
+        assertEquals(42.25, rangeJson.getDouble("max"), 0.0)
+        assertEquals(7.5, rangeJson.getDouble("current"), 0.0)
+    }
+
     private fun node(name: String): AccessibilityNodeInfo {
         return mockk(name = name, relaxed = true)
     }


### PR DESCRIPTION
## Summary

- Serialize non-finite accessibility range values as JSON `null`.
- Preserve finite `min`, `max`, and `current` values and the range `type`.
- Add JVM regressions for `-Infinity`, `+Infinity`, `NaN`, and finite ranges.
- Add an Android instrumentation regression using a real framework-sealed accessibility node with unbounded range bounds.

## Root cause

Android permits accessibility ranges with infinite bounds. Portal copied those values directly into its accessibility-tree JSON, but JSON encoding rejects non-finite numbers with `Forbidden numeric value: -Infinity`. As a result, `state_full`/`get_state` failed and the client repeatedly retried an unrecoverable serialization error.

## User impact

Accessibility trees containing unbounded ranges now return valid JSON. Consumers receive `null` for non-finite range fields instead of losing the entire device state response.

## Validation

- Focused `AccessibilityTreeBuilderTest`: 7/7 passed
- Debug Portal APK and Android test APK built successfully
- Android 16/API 36 instrumentation regression: passed
- Live `state_full` validation: successful valid JSON with no forbidden numeric-value error
- Full JVM suite: 482/483 passed. The remaining failure is the unrelated pre-existing `SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates` color mismatch (`#0D9373` expected, `#4566D9` actual); the relevant resources and test are unchanged from `origin/main`

References droidrun/mobilerun#386.