### PR TITLE
fix(stream): accurate remote taps when capture aspect differs from screen

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -47,6 +47,7 @@ import com.mobilerun.portal.keepalive.KeepAliveStartupException
 import org.webrtc.IceCandidate
 import org.webrtc.PeerConnection
 import com.mobilerun.portal.service.AutoAcceptGate
+import com.mobilerun.portal.service.CaptureSizing
 import com.mobilerun.portal.service.FileOperations
 import com.mobilerun.portal.service.ReverseConnectionService
 import android.app.NotificationChannel
@@ -88,6 +89,22 @@ class ApiHandler(
         const val EXTRA_INSTALL_PACKAGE = "install_package"
         private const val INSTALL_NOTIFICATION_CHANNEL_ID = "install_result_channel"
         private const val INSTALL_NOTIFICATION_ID = 4001
+
+        /**
+         * True for an explicit numeric value, or a numeric string (legacy `optInt`
+         * parsed numeric strings too, so a string width/height must still count as
+         * present). JSONObject.NULL, non-numeric strings, and other types count as
+         * absent.
+         */
+        fun isNumericCaptureParam(params: JSONObject, key: String): Boolean {
+            if (!params.has(key)) return false
+            val value = params.opt(key)
+            return when (value) {
+                is Number -> true
+                is String -> value.toDoubleOrNull() != null
+                else -> false
+            }
+        }
     }
 
     private val installLock = Any()
@@ -102,6 +119,24 @@ class ApiHandler(
     }
     val applicationContext: Context
         get() = context.applicationContext
+
+    private fun defaultCaptureSize(params: JSONObject): Pair<Int, Int> {
+        if (isNumericCaptureParam(params, "width") || isNumericCaptureParam(params, "height")) {
+            return Pair(
+                params.optInt("width", CaptureSizing.DEFAULT_CAPTURE_WIDTH)
+                    .coerceIn(CaptureSizing.CAPTURE_WIDTH_MIN, CaptureSizing.CAPTURE_WIDTH_MAX),
+                params.optInt("height", CaptureSizing.DEFAULT_CAPTURE_HEIGHT)
+                    .coerceIn(CaptureSizing.CAPTURE_HEIGHT_MIN, CaptureSizing.CAPTURE_HEIGHT_MAX),
+            )
+        }
+
+        return CaptureSizing.deriveAutoCaptureSize(context)
+    }
+
+    /** True when [defaultCaptureSize] would take the auto-derive path for these params. */
+    private fun isAutoDerivedCaptureSize(params: JSONObject): Boolean {
+        return !isNumericCaptureParam(params, "width") && !isNumericCaptureParam(params, "height")
+    }
 
     private fun getAvailableInternalBytes(): Long? {
         return try {
@@ -1931,8 +1966,8 @@ class ApiHandler(
     }
 
     fun startStream(params: JSONObject): ApiResponse {
-        val width = params.optInt("width", 720).coerceIn(144, 1920)
-        val height = params.optInt("height", 1280).coerceIn(256, 3840)
+        val (width, height) = defaultCaptureSize(params)
+        val sizeAutoDerived = isAutoDerivedCaptureSize(params)
         val fps = params.optInt("fps", 30).coerceIn(1, 60)
         val sessionId = params.optString("sessionId").trim()
         if (sessionId.isEmpty()) {
@@ -1968,6 +2003,7 @@ class ApiHandler(
                 putExtra(com.mobilerun.portal.ui.ScreenCaptureActivity.EXTRA_MODE, com.mobilerun.portal.ui.ScreenCaptureActivity.MODE_STREAM)
                 putExtra(ScreenCaptureService.EXTRA_WIDTH, width)
                 putExtra(ScreenCaptureService.EXTRA_HEIGHT, height)
+                putExtra(ScreenCaptureService.EXTRA_SIZE_AUTO_DERIVED, sizeAutoDerived)
                 putExtra(ScreenCaptureService.EXTRA_FPS, fps)
                 putExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, waitForOffer)
             }
@@ -2063,8 +2099,7 @@ class ApiHandler(
         if (sessionId.isEmpty()) {
             return ApiResponse.Error("Missing required param: 'sessionId'")
         }
-        val width = params.optInt("width", 720).coerceIn(144, 1920)
-        val height = params.optInt("height", 1280).coerceIn(256, 3840)
+        val (width, height) = defaultCaptureSize(params)
         val fps = params.optInt("fps", 30).coerceIn(1, 60)
 
         val manager = WebRtcManager.getInstance(context)

--- a/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
@@ -1,0 +1,121 @@
+package com.mobilerun.portal.service
+
+import android.content.Context
+import android.os.Build
+import android.content.res.Resources
+import android.util.Log
+
+/**
+ * Derives the MediaProjection capture size (legacy 720x1280 default, or an
+ * aspect-fit into that box) from the device's real display metrics.
+ *
+ * Kept as a neutral object with no dependency on [com.mobilerun.portal.api.ApiHandler]
+ * so that [ScreenCaptureService] (which needs to re-derive the size at
+ * permission-grant time) does not have to import the api package — that
+ * import used to create an api↔service package cycle.
+ */
+object CaptureSizing {
+    private const val TAG = "CaptureSizing"
+
+    const val DEFAULT_CAPTURE_WIDTH = 720
+    const val DEFAULT_CAPTURE_HEIGHT = 1280
+    const val CAPTURE_WIDTH_MIN = 144
+    const val CAPTURE_WIDTH_MAX = 1920
+    const val CAPTURE_HEIGHT_MIN = 256
+    const val CAPTURE_HEIGHT_MAX = 3840
+
+    // Aspect-fits the real screen into the legacy 720x1280 default capture box
+    // (never upscaled) so MediaProjection doesn't bake pillarbox/letterbox bars
+    // into the frame. Dimensions are rounded down to even and clamped to the
+    // existing per-field bounds. If clamping would actually change either
+    // dimension (i.e. the fitted size falls outside the legacy bounds), the
+    // fit is rejected outright rather than returning a distorted aspect ratio
+    // — callers fall back to the legacy 720x1280 default (Fix B in the
+    // injection path handles any residual mismatch).
+    fun fitCaptureSizeToScreen(screenWidth: Int, screenHeight: Int): Pair<Int, Int>? {
+        if (screenWidth <= 0 || screenHeight <= 0) return null
+
+        val candidateWidthScale = DEFAULT_CAPTURE_WIDTH.toDouble() / screenWidth
+        val candidateHeightScale = DEFAULT_CAPTURE_HEIGHT.toDouble() / screenHeight
+        // No-upscale guard: never scale up past 1.0.
+        val scale = minOf(candidateWidthScale, candidateHeightScale, 1.0)
+
+        val width: Int
+        val height: Int
+        if (scale >= 1.0) {
+            // Screen already fits inside the legacy box on both axes —
+            // keep the screen's own size (floored to even) rather than
+            // stretching either axis out to a box value that doesn't
+            // apply here.
+            width = floorToEven(screenWidth.toDouble())
+            height = floorToEven(screenHeight.toDouble())
+        } else if (candidateWidthScale <= candidateHeightScale) {
+            // Width is the limiting axis: assign it the box value
+            // EXACTLY rather than deriving it via scale*screenWidth,
+            // which can undershoot by a fraction of a pixel and
+            // floor-even one lower than intended (e.g. 1080x2139 →
+            // 646x1278 instead of 646x1280). Only the other axis is
+            // floor-even'd from the float/double math.
+            width = DEFAULT_CAPTURE_WIDTH
+            height = floorToEven(screenHeight * scale)
+        } else {
+            height = DEFAULT_CAPTURE_HEIGHT
+            width = floorToEven(screenWidth * scale)
+        }
+        if (width <= 0 || height <= 0) return null
+
+        val clampedWidth = width.coerceIn(CAPTURE_WIDTH_MIN, CAPTURE_WIDTH_MAX)
+        val clampedHeight = height.coerceIn(CAPTURE_HEIGHT_MIN, CAPTURE_HEIGHT_MAX)
+        if (clampedWidth != width || clampedHeight != height) return null
+
+        return Pair(clampedWidth, clampedHeight)
+    }
+
+    private fun floorToEven(value: Double): Int {
+        val floored = kotlin.math.floor(value).toInt()
+        return if (floored % 2 != 0) floored - 1 else floored
+    }
+
+    /**
+     * Reads the current display bounds directly from a [Context], with no
+     * dependency on an ApiHandler instance. Exposed so callers that only
+     * have a Context at hand (e.g. ScreenCaptureService re-deriving the
+     * capture size at permission-grant time, after a possible rotation)
+     * can reuse the exact same display-metrics logic instead of
+     * duplicating it.
+     */
+    fun readDisplaySize(context: Context): Pair<Int, Int>? {
+        return try {
+            val wm = context.getSystemService(Context.WINDOW_SERVICE) as? android.view.WindowManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                val bounds = wm?.maximumWindowMetrics?.bounds
+                Pair(
+                    bounds?.width() ?: Resources.getSystem().displayMetrics.widthPixels,
+                    bounds?.height() ?: Resources.getSystem().displayMetrics.heightPixels,
+                )
+            } else {
+                val metrics = android.util.DisplayMetrics()
+                @Suppress("DEPRECATION")
+                wm?.defaultDisplay?.getRealMetrics(metrics)
+                Pair(metrics.widthPixels, metrics.heightPixels)
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to read display size for default capture size", e)
+            null
+        }
+    }
+
+    /**
+     * The "auto" default capture size for the screen currently reported by
+     * [context]: an aspect-fit into the legacy 720x1280 box, falling back
+     * to that legacy default outright if the display can't be read or
+     * doesn't fit within bounds. Used both for the pre-permission-prompt
+     * default and for re-deriving the size at permission-grant time (Fix
+     * for stale-orientation dims baked in while the prompt was open).
+     */
+    fun deriveAutoCaptureSize(context: Context): Pair<Int, Int> {
+        val screenSize = readDisplaySize(context)
+        val fitted = screenSize?.let { (w, h) -> fitCaptureSizeToScreen(w, h) }
+        return fitted ?: Pair(DEFAULT_CAPTURE_WIDTH, DEFAULT_CAPTURE_HEIGHT)
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/service/ScreenCaptureService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ScreenCaptureService.kt
@@ -33,6 +33,14 @@ class ScreenCaptureService : Service() {
 
         const val EXTRA_WIDTH = "width"
         const val EXTRA_HEIGHT = "height"
+        // True only when ApiHandler used the auto-derive path (neither width
+        // nor height was explicitly requested) to compute EXTRA_WIDTH/HEIGHT.
+        // Those dims were computed before the MediaProjection permission
+        // activity launched; if the device rotates while that prompt is on
+        // screen, they go stale. When this flag is set we re-run the same
+        // fit here, after the permission grant, instead of trusting the
+        // extras. Explicit width/height requests are unaffected (flag false).
+        const val EXTRA_SIZE_AUTO_DERIVED = "size_auto_derived"
         const val EXTRA_FPS = "fps"
         const val EXTRA_WAIT_FOR_OFFER = "wait_for_offer"
 
@@ -74,8 +82,20 @@ class ScreenCaptureService : Service() {
                 val resultCode = intent.getIntExtra(EXTRA_RESULT_CODE, 0)
                 val resultData = intent.getParcelableExtra<Intent>(EXTRA_RESULT_DATA)
                 val captureMode = intent.getStringExtra(EXTRA_CAPTURE_MODE) ?: CAPTURE_MODE_STREAM
-                val width = intent.getIntExtra(EXTRA_WIDTH, 720)
-                val height = intent.getIntExtra(EXTRA_HEIGHT, 1280)
+                val requestedWidth = intent.getIntExtra(EXTRA_WIDTH, 720)
+                val requestedHeight = intent.getIntExtra(EXTRA_HEIGHT, 1280)
+                val sizeAutoDerived = intent.getBooleanExtra(EXTRA_SIZE_AUTO_DERIVED, false)
+                // Re-derive the auto-fit size now, at permission-grant time,
+                // instead of trusting dims computed before the permission
+                // prompt launched — a rotation while the prompt was open
+                // would otherwise bake stale-orientation dims into the
+                // VirtualDisplay. Explicit width/height requests skip this
+                // (sizeAutoDerived is false) and use the extras as-is.
+                val (width, height) = if (sizeAutoDerived) {
+                    CaptureSizing.deriveAutoCaptureSize(applicationContext)
+                } else {
+                    Pair(requestedWidth, requestedHeight)
+                }
                 val fps = intent.getIntExtra(EXTRA_FPS, 30)
                 val waitForOffer = intent.getBooleanExtra(EXTRA_WAIT_FOR_OFFER, false)
 

--- a/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyControlChannel.kt
+++ b/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyControlChannel.kt
@@ -30,12 +30,72 @@ class ScrcpyControlChannel : DataChannel.Observer {
 
         private const val MIN_GESTURE_DURATION_MS = 50L
         private const val MAX_GESTURE_DURATION_MS = 5000L
+
+        // MediaProjection captures the full display with a centered, uniform
+        // aspect-fit into the video canvas (no inset/cutout math). A point that
+        // lands in the resulting pillarbox/letterbox bars has no corresponding
+        // screen position and must not be injected as a tap.
+        fun mapFrameToScreen(
+            x: Int,
+            y: Int,
+            videoW: Int,
+            videoH: Int,
+            screenW: Int,
+            screenH: Int,
+        ): Pair<Float, Float>? {
+            if (videoW <= 0 || videoH <= 0 || screenW <= 0 || screenH <= 0) return null
+
+            val scaleX = videoW.toDouble() / screenW
+            val scaleY = videoH.toDouble() / screenH
+            val scale = minOf(scaleX, scaleY)
+
+            // The limiting axis (whichever of scaleX/scaleY is the min) fits
+            // the video canvas edge-to-edge, so its offset must be EXACTLY
+            // 0.0 — not the result of a floating-point subtraction, which can
+            // leave a residual of a few ten-thousandths of a pixel (e.g.
+            // video=720x1280 vs screen=1080x2408 previously computed
+            // offsetY≈0.000061 instead of 0) that's enough to push a
+            // legitimate edge tap (y=0) outside the bounds check below and
+            // have it misclassified as a pillarbox/letterbox bar point.
+            val offsetX: Double
+            val offsetY: Double
+            if (scaleX <= scaleY) {
+                offsetX = 0.0
+                offsetY = (videoH - screenH * scale) / 2.0
+            } else {
+                offsetX = (videoW - screenW * scale) / 2.0
+                offsetY = 0.0
+            }
+
+            val frameX = x.toDouble()
+            val frameY = y.toDouble()
+            if (frameX < offsetX || frameX > videoW - offsetX ||
+                frameY < offsetY || frameY > videoH - offsetY
+            ) {
+                return null
+            }
+
+            val screenX = (frameX - offsetX) / scale
+            val screenY = (frameY - offsetY) / scale
+
+            return Pair(
+                screenX.toFloat().coerceIn(0f, (screenW - 1).toFloat()),
+                screenY.toFloat().coerceIn(0f, (screenH - 1).toFloat()),
+            )
+        }
     }
 
     private val touchPath = mutableListOf<Pair<Float, Float>>()
     private var touchStartTime = 0L
-    private var lastVideoWidth = 0
-    private var lastVideoHeight = 0
+    private var gestureActive = false
+
+    // The pointer that owns the currently in-flight gesture. Multi-touch
+    // injection stays UNSUPPORTED (dispatchPath below drives a single
+    // GestureDescription stroke), but a second pointer must not corrupt the
+    // active pointer's state: while a gesture is active, DOWN/MOVE/UP from
+    // any other pointer id is ignored outright rather than clearing
+    // touchPath or cancelling a valid gesture.
+    private var activePointerId: Long? = null
 
     override fun onBufferedAmountChange(previousAmount: Long) {}
 
@@ -72,7 +132,7 @@ class ScrcpyControlChannel : DataChannel.Observer {
         buffer.order(ByteOrder.BIG_ENDIAN)
         buffer.get()
         val action = buffer.get().toInt() and 0xFF
-        buffer.long
+        val pointerId = buffer.long
 
         buffer.order(ByteOrder.LITTLE_ENDIAN)
         val x = buffer.int
@@ -81,26 +141,52 @@ class ScrcpyControlChannel : DataChannel.Observer {
         val videoHeight = buffer.short.toInt() and 0xFFFF
         buffer.short
 
-        lastVideoWidth = videoWidth
-        lastVideoHeight = videoHeight
+        // A second pointer while a gesture is active is dropped wholesale —
+        // its DOWN would otherwise clear touchPath out from under the first
+        // pointer, and its bar-DOWN would otherwise cancel a valid running
+        // gesture. The active pointer's own events fall through untouched.
+        if (gestureActive && pointerId != activePointerId) {
+            return
+        }
 
-        val (scaledX, scaledY) = scaleCoordinates(x, y, videoWidth, videoHeight)
+        val mapped = scaleCoordinates(x, y, videoWidth, videoHeight)
 
         when (action) {
             ACTION_DOWN -> {
                 touchPath.clear()
-                touchPath.add(Pair(scaledX, scaledY))
+                if (mapped == null) {
+                    gestureActive = false
+                    activePointerId = null
+                    return
+                }
+                gestureActive = true
+                activePointerId = pointerId
+                touchPath.add(mapped)
                 touchStartTime = System.currentTimeMillis()
             }
             ACTION_MOVE -> {
-                touchPath.add(Pair(scaledX, scaledY))
+                if (!gestureActive) return
+                // A move landing in the bars is dropped, not dispatched as a
+                // partial gesture: keep the gesture alive and skip the point.
+                if (mapped == null) return
+                touchPath.add(mapped)
             }
             ACTION_UP -> {
-                touchPath.add(Pair(scaledX, scaledY))
+                if (!gestureActive) {
+                    touchPath.clear()
+                    return
+                }
+                // UP in the bars intentionally releases at the last valid point —
+                // mirrors the web client (which sends UP at the last inside
+                // position) and scrcpy; cancelling here would swallow
+                // drag-to-edge gestures.
+                (mapped ?: touchPath.lastOrNull())?.let { touchPath.add(it) }
                 val duration = (System.currentTimeMillis() - touchStartTime)
                     .coerceIn(MIN_GESTURE_DURATION_MS, MAX_GESTURE_DURATION_MS)
                 dispatchPath(touchPath.toList(), duration)
                 touchPath.clear()
+                gestureActive = false
+                activePointerId = null
             }
         }
     }
@@ -119,7 +205,7 @@ class ScrcpyControlChannel : DataChannel.Observer {
         val hScroll = buffer.short.toInt()
         val vScroll = buffer.short.toInt()
 
-        val (scaledX, scaledY) = scaleCoordinates(x, y, videoWidth, videoHeight)
+        val (scaledX, scaledY) = scaleCoordinates(x, y, videoWidth, videoHeight) ?: return
 
         val scrollDistance = 200
         val endY = scaledY + (vScroll * scrollDistance)
@@ -276,13 +362,16 @@ class ScrcpyControlChannel : DataChannel.Observer {
         service.inputText(text, false)
     }
 
-    private fun scaleCoordinates(x: Int, y: Int, videoW: Int, videoH: Int): Pair<Float, Float> {
-        if (videoW <= 0 || videoH <= 0) return Pair(x.toFloat(), y.toFloat())
+    private fun scaleCoordinates(x: Int, y: Int, videoW: Int, videoH: Int): Pair<Float, Float>? {
+        val (screenW, screenH) = currentScreenSize()
+        return mapFrameToScreen(x, y, videoW, videoH, screenW, screenH)
+    }
 
+    private fun currentScreenSize(): Pair<Int, Int> {
         val service = MobilerunAccessibilityService.getInstance()
         val wm = service?.getSystemService(android.content.Context.WINDOW_SERVICE) as? android.view.WindowManager
 
-        val (screenW, screenH) = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
             val bounds = wm?.maximumWindowMetrics?.bounds
             Pair(bounds?.width() ?: Resources.getSystem().displayMetrics.widthPixels,
                  bounds?.height() ?: Resources.getSystem().displayMetrics.heightPixels)
@@ -292,11 +381,6 @@ class ScrcpyControlChannel : DataChannel.Observer {
             wm?.defaultDisplay?.getRealMetrics(metrics)
             Pair(metrics.widthPixels, metrics.heightPixels)
         }
-
-        val scaledX = (x.toFloat() / videoW) * screenW
-        val scaledY = (y.toFloat() / videoH) * screenH
-
-        return Pair(scaledX, scaledY)
     }
 
     private fun dispatchPath(points: List<Pair<Float, Float>>, durationMs: Long) {

--- a/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
@@ -54,6 +54,10 @@ class ScreenCaptureActivity : Activity() {
                     // Forward stream config from launching intent
                     putExtra(ScreenCaptureService.EXTRA_WIDTH, intent.getIntExtra(ScreenCaptureService.EXTRA_WIDTH, 720))
                     putExtra(ScreenCaptureService.EXTRA_HEIGHT, intent.getIntExtra(ScreenCaptureService.EXTRA_HEIGHT, 1280))
+                    putExtra(
+                        ScreenCaptureService.EXTRA_SIZE_AUTO_DERIVED,
+                        intent.getBooleanExtra(ScreenCaptureService.EXTRA_SIZE_AUTO_DERIVED, false),
+                    )
                     putExtra(ScreenCaptureService.EXTRA_FPS, intent.getIntExtra(ScreenCaptureService.EXTRA_FPS, 30))
                     putExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, intent.getBooleanExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, false))
                 }

--- a/app/src/test/java/com/mobilerun/portal/api/ApiHandlerCaptureParamTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/ApiHandlerCaptureParamTest.kt
@@ -1,0 +1,26 @@
+package com.mobilerun.portal.api
+
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ApiHandlerCaptureParamTest {
+    @Test
+    fun isNumericCaptureParam_trueForNumbersAndNumericStrings() {
+        val params = JSONObject().apply {
+            put("width", 800)
+            put("widthString", "800")
+            put("heightNull", JSONObject.NULL)
+            put("heightString", "tall")
+        }
+
+        assertTrue(ApiHandler.isNumericCaptureParam(params, "width"))
+        // Legacy `optInt` parsed numeric strings too, so a string value must
+        // still count as present.
+        assertTrue(ApiHandler.isNumericCaptureParam(params, "widthString"))
+        assertFalse(ApiHandler.isNumericCaptureParam(params, "heightNull"))
+        assertFalse(ApiHandler.isNumericCaptureParam(params, "heightString"))
+        assertFalse(ApiHandler.isNumericCaptureParam(params, "missing"))
+    }
+}

--- a/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
@@ -648,6 +648,109 @@ class ApiHandlerTest {
     }
 
     @Test
+    fun connectWebRtc_widthOnlyKeepsLegacyHeightDefault() {
+        // Fix A only derives a capture size when NEITHER key is present; an
+        // explicit width alone must keep the per-field legacy defaulting.
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns true
+        every {
+            manager.startStreamWithExistingCapture(800, 1280, 30, "session-1", true)
+        } just Runs
+
+        val response =
+            handler.connectWebRtc(
+                JSONObject().apply {
+                    put("sessionId", "session-1")
+                    put("width", 800)
+                },
+            )
+
+        assertEquals(ApiResponse.Success("reusing_capture"), response)
+        verify(exactly = 1) {
+            manager.startStreamWithExistingCapture(800, 1280, 30, "session-1", true)
+        }
+    }
+
+    @Test
+    fun connectWebRtc_stringWidthKeepsLegacyHeightDefault() {
+        // A numeric string width (e.g. from a client that JSON-encodes numbers
+        // as strings) must be treated as present, matching legacy `optInt`
+        // parsing behavior: width=800, height falls back to the 1280 default.
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns true
+        every {
+            manager.startStreamWithExistingCapture(800, 1280, 30, "session-1", true)
+        } just Runs
+
+        val response =
+            handler.connectWebRtc(
+                JSONObject().apply {
+                    put("sessionId", "session-1")
+                    put("width", "800")
+                },
+            )
+
+        assertEquals(ApiResponse.Success("reusing_capture"), response)
+        verify(exactly = 1) {
+            manager.startStreamWithExistingCapture(800, 1280, 30, "session-1", true)
+        }
+    }
+
+    @Test
+    fun connectWebRtc_nullWidthTreatedAsAbsentButExplicitHeightKeepsLegacyBranch() {
+        // width is present but JSONObject.NULL (treated as absent for the
+        // presence check); height is genuinely present, so the OR condition
+        // still routes to the legacy per-field branch, where optInt on the
+        // NULL width value falls back to its own 720 default.
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns true
+        every {
+            manager.startStreamWithExistingCapture(720, 1400, 30, "session-1", true)
+        } just Runs
+
+        val response =
+            handler.connectWebRtc(
+                JSONObject().apply {
+                    put("sessionId", "session-1")
+                    put("width", JSONObject.NULL)
+                    put("height", 1400)
+                },
+            )
+
+        assertEquals(ApiResponse.Success("reusing_capture"), response)
+        verify(exactly = 1) {
+            manager.startStreamWithExistingCapture(720, 1400, 30, "session-1", true)
+        }
+    }
+
+    @Test
     fun startStream_reusesActiveCaptureAndBindsReverseService() {
         val stateRepo = mockk<StateRepository>(relaxed = true)
         val context = mockk<Context>(relaxed = true)

--- a/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
@@ -1,0 +1,48 @@
+package com.mobilerun.portal.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CaptureSizingTest {
+    private data class SizingCase(
+        val name: String,
+        val screenWidth: Int,
+        val screenHeight: Int,
+        val expected: Pair<Int, Int>?,
+    )
+
+    @Test
+    fun fitCaptureSizeToScreen_coversAspectFitAndRejectionCases() {
+        val cases =
+            listOf(
+                // 1080x2408 is height-constrained; 574.09 rounds down to
+                // even 574, height lands exactly at the 1280 box limit.
+                SizingCase("portrait height-constrained", 1080, 2408, Pair(574, 1280)),
+                SizingCase("landscape width-constrained", 2408, 1080, Pair(720, 322)),
+                // Same aspect ratio as the legacy 720x1280 box.
+                SizingCase("exact aspect match", 1080, 1920, Pair(720, 1280)),
+                // 1080x2139 is height-constrained; scale*screenHeight
+                // undershoots 1280.0 by a hair (1279.9999...), which used to
+                // floor-even to 1278. The limiting axis (height) must land
+                // on the box value exactly.
+                SizingCase("height-limited axis is exact, not float undershoot", 1080, 2139, Pair(646, 1280)),
+                // 3000x1000 fits to 720x240, but 240 is below the legacy
+                // height minimum (256); clamping it up would distort the
+                // aspect ratio, so the fit is rejected rather than blessed.
+                SizingCase("extreme aspect rejected instead of distorted", 3000, 1000, null),
+                // Screen smaller than the 720x1280 box in both dimensions:
+                // scale is capped at 1.0 (200x200), but 200 is below the
+                // legacy height minimum (256); clamping would change the
+                // fitted height, so the fit is rejected instead of
+                // returning a distorted 200x256.
+                SizingCase("smaller than box rejected when clamp would distort", 200, 200, null),
+                SizingCase("zero width returns null", 0, 100, null),
+                SizingCase("negative height returns null", 100, -5, null),
+            )
+
+        for (case in cases) {
+            val actual = CaptureSizing.fitCaptureSizeToScreen(case.screenWidth, case.screenHeight)
+            assertEquals("${case.name}: fitCaptureSizeToScreen result", case.expected, actual)
+        }
+    }
+}

--- a/app/src/test/java/com/mobilerun/portal/streaming/ScrcpyControlChannelMapperTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/streaming/ScrcpyControlChannelMapperTest.kt
@@ -1,0 +1,131 @@
+package com.mobilerun.portal.streaming
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ScrcpyControlChannelMapperTest {
+    private data class MapperCase(
+        val name: String,
+        val x: Int,
+        val y: Int,
+        val videoW: Int,
+        val videoH: Int,
+        val screenW: Int,
+        val screenH: Int,
+        val expectNull: Boolean = false,
+        val expectedX: Float? = null,
+        val expectedY: Float? = null,
+        val tolerance: Float = 0.01f,
+    )
+
+    @Test
+    fun mapFrameToScreen_coversBarPointsAndEdgeCases() {
+        val cases =
+            listOf(
+                // video 720x1280, screen 1080x2408: height-constrained fit
+                // leaves a left/right bar of ~72.9px in frame coordinates.
+                MapperCase(
+                    name = "pillarbox bar point returns null",
+                    x = 10, y = 640,
+                    videoW = 720, videoH = 1280, screenW = 1080, screenH = 2408,
+                    expectNull = true,
+                ),
+                MapperCase(
+                    name = "pillarbox frame center maps to screen center",
+                    x = 360, y = 640,
+                    videoW = 720, videoH = 1280, screenW = 1080, screenH = 2408,
+                    expectedX = 540f, expectedY = 1204f, tolerance = 1f,
+                ),
+                // video 720x1280, screen 720x1000: width-constrained fit
+                // leaves a top/bottom bar of 140px in frame coordinates.
+                MapperCase(
+                    name = "letterbox bar point returns null",
+                    x = 360, y = 50,
+                    videoW = 720, videoH = 1280, screenW = 720, screenH = 1000,
+                    expectNull = true,
+                ),
+                MapperCase(
+                    name = "exact aspect match passes through unscaled",
+                    x = 360, y = 640,
+                    videoW = 720, videoH = 1280, screenW = 720, screenH = 1280,
+                    expectedX = 360f, expectedY = 640f,
+                ),
+                MapperCase(
+                    name = "x == videoW edge clamps to screenW - 1",
+                    x = 720, y = 0,
+                    videoW = 720, videoH = 1280, screenW = 720, screenH = 1280,
+                    expectedX = 719f, expectedY = 0f,
+                ),
+                MapperCase(
+                    name = "zero videoW returns null",
+                    x = 0, y = 0,
+                    videoW = 0, videoH = 1280, screenW = 720, screenH = 1280,
+                    expectNull = true,
+                ),
+                MapperCase(
+                    name = "zero videoH returns null",
+                    x = 0, y = 0,
+                    videoW = 720, videoH = 0, screenW = 720, screenH = 1280,
+                    expectNull = true,
+                ),
+                MapperCase(
+                    name = "negative screenW returns null",
+                    x = 0, y = 0,
+                    videoW = 720, videoH = 1280, screenW = -1, screenH = 1280,
+                    expectNull = true,
+                ),
+                MapperCase(
+                    name = "zero screenH returns null",
+                    x = 0, y = 0,
+                    videoW = 720, videoH = 1280, screenW = 720, screenH = 0,
+                    expectNull = true,
+                ),
+                // Regression: video 720x1280 vs screen 1080x2408 is
+                // height-limited, so offsetY must be exactly 0.0. Float math
+                // previously computed offsetY as a tiny positive residual
+                // (~0.000061), which pushed a legitimate y=0 edge tap outside
+                // the bounds check and dropped it.
+                MapperCase(
+                    name = "flush y=0 on height-limited fit maps non-null",
+                    x = 360, y = 0,
+                    videoW = 720, videoH = 1280, screenW = 1080, screenH = 2408,
+                ),
+                // Landscape/width-limited analogue: video 1280x720 vs screen
+                // 2408x1080 is width-limited, so offsetX must be exactly 0.0
+                // and a legitimate x=0 edge tap must not be misclassified as
+                // a bar point.
+                MapperCase(
+                    name = "flush x=0 on width-limited fit maps non-null",
+                    x = 0, y = 360,
+                    videoW = 1280, videoH = 720, screenW = 2408, screenH = 1080,
+                ),
+            )
+
+        for (case in cases) {
+            val mapped =
+                ScrcpyControlChannel.mapFrameToScreen(
+                    x = case.x,
+                    y = case.y,
+                    videoW = case.videoW,
+                    videoH = case.videoH,
+                    screenW = case.screenW,
+                    screenH = case.screenH,
+                )
+
+            if (case.expectNull) {
+                assertNull("${case.name}: expected null mapping", mapped)
+            } else {
+                assertNotNull("${case.name}: expected non-null mapping", mapped)
+                requireNotNull(mapped)
+                if (case.expectedX != null) {
+                    assertEquals("${case.name}: screenX", case.expectedX, mapped.first, case.tolerance)
+                }
+                if (case.expectedY != null) {
+                    assertEquals("${case.name}: screenY", case.expectedY, mapped.second, case.tolerance)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Remote-control taps don't land exactly where the user clicks whenever the capture resolution's aspect ratio differs from the device screen's aspect ratio. Two compounding causes inside the app:

1. **Fixed default capture size.** When a stream is started without explicit `width`/`height` params, capture defaults to 720×1280 (9:16). Modern phones are ~9:20, so MediaProjection letterboxes the mirrored screen into the capture surface — black pillarbox bars are baked into the encoded video, and ~20% of the encoder width is wasted on bars.
2. **Letterbox-unaware input mapping.** `ScrcpyControlChannel.scaleCoordinates` mapped incoming frame coordinates to screen coordinates by stretching each axis independently (`x/videoW*screenW`, `y/videoH*screenH`). That is only correct when frame aspect == screen aspect. With bars in the frame, taps get pulled toward the screen center — up to ~10% of the screen width off near the edges.

## Changes

**Aspect-correct default capture size** (`ApiHandler`, new `CaptureSizing`)
- When *neither* `width` nor `height` is present in the stream request, the capture size is now derived from the real display: aspect-fit into the legacy 720×1280 box (never upscaled), floored to even dimensions. If the result would fall outside the accepted bounds (144–1920 / 256–3840), the legacy 720×1280 default is used unchanged.
- The auto-derived size is re-computed at permission-grant time (`EXTRA_SIZE_AUTO_DERIVED`), so a rotation while the MediaProjection prompt is open doesn't bake stale-orientation dimensions into the virtual display.

**Letterbox-aware input mapping** (`ScrcpyControlChannel`)
- New pure `mapFrameToScreen`: inverse aspect-fit (uniform scale, centered offsets, double precision with an exact-zero offset on the limiting axis so flush-edge taps at x=0/y=0 aren't dropped). Points landing in the bars map to `null` instead of a wrong screen position.
- Gesture state machine hardened: a DOWN in the bars drops the whole gesture (no partial dispatch from later MOVE/UP), a MOVE in the bars skips the point but keeps the gesture, an UP in the bars releases at the last valid point (matches how remote clients report releases; cancelling would swallow drag-to-edge gestures). The packet's pointer id is now latched so a second concurrent pointer can no longer corrupt the active gesture's path.
- Scroll events in the bars are dropped.

## Backwards compatibility

- **Explicit `width`/`height` requests behave byte-for-byte as before**, including per-field defaults (width-only keeps height 1280 and vice versa), numeric strings (`"800"`), and the existing `coerceIn` bounds. `JSONObject.NULL` and non-numeric values count as absent, matching `optInt` outcomes.
- No wire/protocol changes: same RPC methods, same message formats. Servers that already send `width`/`height` are unaffected; only the *default* used when no dimensions are requested changes.
- Multi-touch injection remains unsupported (single-stroke gestures), as before — it just can no longer corrupt gesture state.

## Tests

- `ScrcpyControlChannelMapperTest`: table-driven coverage of the mapping (bar rejection, center/edge correctness, exact-aspect passthrough, flush-edge float regressions, invalid dims).
- `CaptureSizingTest`: size derivation (portrait/landscape fit, exact limiting-axis fitting incl. float-undershoot regression, bounds rejection, invalid input).
- `ApiHandlerTest` additions: legacy per-field param behavior (width-only, numeric-string width, `NULL` width).
- Full unit suite and `assembleDebug` pass (one pre-existing, unrelated `SwitchTintResourceTest` failure reproduces on a clean baseline).

> **Note:** verified via unit tests and build only so far — on-device click-accuracy verification (pointer-location overlay, corner taps) is still pending and should gate the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
