### PR TITLE
fix(stream): auto-size BYO captures and correct remote input

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -41,6 +41,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import androidx.core.net.toUri
 import com.mobilerun.portal.service.ScreenCaptureService
+import com.mobilerun.portal.service.CaptureSizing
 import com.mobilerun.portal.streaming.WebRtcManager
 import com.mobilerun.portal.keepalive.KeepAliveController
 import com.mobilerun.portal.keepalive.KeepAliveStartupException
@@ -54,6 +55,7 @@ import android.app.NotificationManager
 import androidx.core.app.NotificationCompat
 import com.mobilerun.portal.state.AppVisibilityTracker
 import com.mobilerun.portal.ui.PermissionDialogActivity
+import com.mobilerun.portal.ui.ScreenCaptureActivity
 import java.util.Collections
 import java.util.IdentityHashMap
 import java.util.Locale
@@ -102,6 +104,28 @@ class ApiHandler(
     }
     val applicationContext: Context
         get() = context.applicationContext
+
+    private data class CaptureSizeSelection(
+        val width: Int,
+        val height: Int,
+        val auto: Boolean,
+    ) {
+        fun resolve(context: Context): Pair<Int, Int> =
+            if (auto) {
+                CaptureSizing.deriveAutoCaptureSize(context)
+            } else {
+                Pair(width, height)
+            }
+    }
+
+    private fun selectCaptureSize(params: JSONObject): CaptureSizeSelection =
+        CaptureSizeSelection(
+            width = params.optInt("width", CaptureSizing.DEFAULT_CAPTURE_WIDTH)
+                .coerceIn(CaptureSizing.CAPTURE_WIDTH_MIN, CaptureSizing.CAPTURE_WIDTH_MAX),
+            height = params.optInt("height", CaptureSizing.DEFAULT_CAPTURE_HEIGHT)
+                .coerceIn(CaptureSizing.CAPTURE_HEIGHT_MIN, CaptureSizing.CAPTURE_HEIGHT_MAX),
+            auto = !params.has("width") && !params.has("height"),
+        )
 
     private fun getAvailableInternalBytes(): Long? {
         return try {
@@ -1931,8 +1955,7 @@ class ApiHandler(
     }
 
     fun startStream(params: JSONObject): ApiResponse {
-        val width = params.optInt("width", 720).coerceIn(144, 1920)
-        val height = params.optInt("height", 1280).coerceIn(256, 3840)
+        val captureSize = selectCaptureSize(params)
         val fps = params.optInt("fps", 30).coerceIn(1, 60)
         val sessionId = params.optString("sessionId").trim()
         if (sessionId.isEmpty()) {
@@ -1948,6 +1971,7 @@ class ApiHandler(
 
         if (manager.isCaptureActive()) {
             return try {
+                val (width, height) = captureSize.resolve(context)
                 manager.startStreamWithExistingCapture(
                     width = width,
                     height = height,
@@ -1963,11 +1987,12 @@ class ApiHandler(
         }
 
         val intent =
-            Intent(context, com.mobilerun.portal.ui.ScreenCaptureActivity::class.java).apply {
+            Intent(context, ScreenCaptureActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-                putExtra(com.mobilerun.portal.ui.ScreenCaptureActivity.EXTRA_MODE, com.mobilerun.portal.ui.ScreenCaptureActivity.MODE_STREAM)
-                putExtra(ScreenCaptureService.EXTRA_WIDTH, width)
-                putExtra(ScreenCaptureService.EXTRA_HEIGHT, height)
+                putExtra(ScreenCaptureActivity.EXTRA_MODE, ScreenCaptureActivity.MODE_STREAM)
+                putExtra(ScreenCaptureActivity.EXTRA_AUTO_CAPTURE_SIZE, captureSize.auto)
+                putExtra(ScreenCaptureService.EXTRA_WIDTH, captureSize.width)
+                putExtra(ScreenCaptureService.EXTRA_HEIGHT, captureSize.height)
                 putExtra(ScreenCaptureService.EXTRA_FPS, fps)
                 putExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, waitForOffer)
             }
@@ -2063,8 +2088,7 @@ class ApiHandler(
         if (sessionId.isEmpty()) {
             return ApiResponse.Error("Missing required param: 'sessionId'")
         }
-        val width = params.optInt("width", 720).coerceIn(144, 1920)
-        val height = params.optInt("height", 1280).coerceIn(256, 3840)
+        val captureSize = selectCaptureSize(params)
         val fps = params.optInt("fps", 30).coerceIn(1, 60)
 
         val manager = WebRtcManager.getInstance(context)
@@ -2081,6 +2105,7 @@ class ApiHandler(
 
         return try {
             if (manager.isCaptureActive()) {
+                val (width, height) = captureSize.resolve(context)
                 manager.startStreamWithExistingCapture(
                     width = width,
                     height = height,

--- a/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
@@ -1,0 +1,117 @@
+package com.mobilerun.portal.service
+
+import android.content.Context
+import android.os.Build
+import android.util.DisplayMetrics
+import android.util.Log
+import android.view.WindowManager
+
+/**
+ * Derives an aspect-correct capture size when a stream request omits both
+ * dimensions.
+ *
+ * The legacy 720x1280 size remains the bounding box and fallback. Explicit
+ * stream dimensions do not pass through this helper.
+ */
+internal object CaptureSizing {
+    private const val TAG = "CaptureSizing"
+
+    const val DEFAULT_CAPTURE_WIDTH = 720
+    const val DEFAULT_CAPTURE_HEIGHT = 1280
+    const val CAPTURE_WIDTH_MIN = 144
+    const val CAPTURE_WIDTH_MAX = 1920
+    const val CAPTURE_HEIGHT_MIN = 256
+    const val CAPTURE_HEIGHT_MAX = 3840
+
+    private val legacyCaptureSize =
+        Pair(DEFAULT_CAPTURE_WIDTH, DEFAULT_CAPTURE_HEIGHT)
+
+    /**
+     * Aspect-fits the screen into the legacy capture box without upscaling.
+     *
+     * Cross-products and integer division avoid floating-point underflow at
+     * exact aspect ratios. A result outside the existing stream bounds is
+     * rejected wholesale instead of clamping one axis and distorting it.
+     */
+    fun fitCaptureSizeToScreen(
+        screenWidth: Int,
+        screenHeight: Int,
+    ): Pair<Int, Int>? {
+        if (screenWidth <= 0 || screenHeight <= 0) return null
+
+        val fittedWidth: Long
+        val fittedHeight: Long
+        if (
+            screenWidth <= DEFAULT_CAPTURE_WIDTH &&
+            screenHeight <= DEFAULT_CAPTURE_HEIGHT
+        ) {
+            fittedWidth = floorToEven(screenWidth.toLong())
+            fittedHeight = floorToEven(screenHeight.toLong())
+        } else {
+            val widthIsLimiting =
+                DEFAULT_CAPTURE_WIDTH.toLong() * screenHeight <=
+                    DEFAULT_CAPTURE_HEIGHT.toLong() * screenWidth
+
+            if (widthIsLimiting) {
+                fittedWidth = DEFAULT_CAPTURE_WIDTH.toLong()
+                fittedHeight =
+                    floorToEven(
+                        screenHeight.toLong() * DEFAULT_CAPTURE_WIDTH / screenWidth,
+                    )
+            } else {
+                fittedWidth =
+                    floorToEven(
+                        screenWidth.toLong() * DEFAULT_CAPTURE_HEIGHT / screenHeight,
+                    )
+                fittedHeight = DEFAULT_CAPTURE_HEIGHT.toLong()
+            }
+        }
+
+        if (
+            fittedWidth !in CAPTURE_WIDTH_MIN.toLong()..CAPTURE_WIDTH_MAX.toLong() ||
+            fittedHeight !in CAPTURE_HEIGHT_MIN.toLong()..CAPTURE_HEIGHT_MAX.toLong()
+        ) {
+            return null
+        }
+
+        return Pair(fittedWidth.toInt(), fittedHeight.toInt())
+    }
+
+    fun deriveAutoCaptureSize(
+        screenWidth: Int,
+        screenHeight: Int,
+    ): Pair<Int, Int> =
+        fitCaptureSizeToScreen(screenWidth, screenHeight) ?: legacyCaptureSize
+
+    /**
+     * Resolves the current screen size, falling back atomically to the legacy
+     * capture size if display lookup or aspect fitting fails.
+     */
+    fun deriveAutoCaptureSize(context: Context): Pair<Int, Int> {
+        val screenSize = readDisplaySize(context) ?: return legacyCaptureSize
+        return deriveAutoCaptureSize(screenSize.first, screenSize.second)
+    }
+
+    fun readDisplaySize(context: Context): Pair<Int, Int>? {
+        return try {
+            val windowManager =
+                context.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+                    ?: return null
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val bounds = windowManager.maximumWindowMetrics.bounds
+                Pair(bounds.width(), bounds.height())
+            } else {
+                val metrics = DisplayMetrics()
+                @Suppress("DEPRECATION")
+                windowManager.defaultDisplay.getRealMetrics(metrics)
+                Pair(metrics.widthPixels, metrics.heightPixels)
+            }
+        } catch (error: Exception) {
+            Log.w(TAG, "Failed to read display size for automatic capture sizing", error)
+            null
+        }
+    }
+
+    private fun floorToEven(value: Long): Long = value - (value % 2L)
+}

--- a/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyControlChannel.kt
+++ b/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyControlChannel.kt
@@ -16,7 +16,7 @@ class ScrcpyControlChannel : DataChannel.Observer {
     companion object {
         private const val TYPE_INJECT_KEYCODE = 0
         private const val TYPE_INJECT_TEXT = 1
-        private const val TYPE_INJECT_TOUCH_EVENT = 2
+        private const val TYPE_INJECT_TOUCH_EVENT = ScrcpyTouchPacketDecoder.MESSAGE_TYPE
         private const val TYPE_INJECT_SCROLL_EVENT = 3
         private const val TYPE_BACK_OR_SCREEN_ON = 4
         private const val TYPE_EXPAND_NOTIFICATION_PANEL = 5
@@ -25,17 +25,13 @@ class ScrcpyControlChannel : DataChannel.Observer {
         private const val TYPE_SET_CLIPBOARD = 9
 
         private const val ACTION_DOWN = 0
-        private const val ACTION_UP = 1
-        private const val ACTION_MOVE = 2
-
         private const val MIN_GESTURE_DURATION_MS = 50L
         private const val MAX_GESTURE_DURATION_MS = 5000L
     }
 
     private val touchPath = mutableListOf<Pair<Float, Float>>()
+    private val touchState = SinglePointerGestureState()
     private var touchStartTime = 0L
-    private var lastVideoWidth = 0
-    private var lastVideoHeight = 0
 
     override fun onBufferedAmountChange(previousAmount: Long) {}
 
@@ -65,43 +61,33 @@ class ScrcpyControlChannel : DataChannel.Observer {
     }
 
     private fun handleTouch(data: ByteArray) {
-        if (data.size < 32) return
+        val packet = ScrcpyTouchPacketDecoder.decode(data) ?: return
+        val mappedPoint =
+            scaleCoordinates(
+                packet.x,
+                packet.y,
+                packet.videoWidth,
+                packet.videoHeight,
+            )
 
-        val buffer = ByteBuffer.wrap(data)
-
-        buffer.order(ByteOrder.BIG_ENDIAN)
-        buffer.get()
-        val action = buffer.get().toInt() and 0xFF
-        buffer.long
-
-        buffer.order(ByteOrder.LITTLE_ENDIAN)
-        val x = buffer.int
-        val y = buffer.int
-        val videoWidth = buffer.short.toInt() and 0xFFFF
-        val videoHeight = buffer.short.toInt() and 0xFFFF
-        buffer.short
-
-        lastVideoWidth = videoWidth
-        lastVideoHeight = videoHeight
-
-        val (scaledX, scaledY) = scaleCoordinates(x, y, videoWidth, videoHeight)
-
-        when (action) {
-            ACTION_DOWN -> {
+        when (val update = touchState.consume(packet.action, packet.pointerId, mappedPoint)) {
+            is TouchGestureUpdate.Started -> {
                 touchPath.clear()
-                touchPath.add(Pair(scaledX, scaledY))
+                touchPath.add(Pair(update.point.x, update.point.y))
                 touchStartTime = System.currentTimeMillis()
             }
-            ACTION_MOVE -> {
-                touchPath.add(Pair(scaledX, scaledY))
+            is TouchGestureUpdate.Moved -> {
+                touchPath.add(Pair(update.point.x, update.point.y))
             }
-            ACTION_UP -> {
-                touchPath.add(Pair(scaledX, scaledY))
+            is TouchGestureUpdate.Finished -> {
+                touchPath.add(Pair(update.point.x, update.point.y))
                 val duration = (System.currentTimeMillis() - touchStartTime)
                     .coerceIn(MIN_GESTURE_DURATION_MS, MAX_GESTURE_DURATION_MS)
                 dispatchPath(touchPath.toList(), duration)
                 touchPath.clear()
             }
+            TouchGestureUpdate.Cancelled -> touchPath.clear()
+            TouchGestureUpdate.Ignored -> Unit
         }
     }
 
@@ -119,7 +105,9 @@ class ScrcpyControlChannel : DataChannel.Observer {
         val hScroll = buffer.short.toInt()
         val vScroll = buffer.short.toInt()
 
-        val (scaledX, scaledY) = scaleCoordinates(x, y, videoWidth, videoHeight)
+        val (scaledX, scaledY) =
+            scaleCoordinates(x, y, videoWidth, videoHeight)?.let { Pair(it.x, it.y) }
+                ?: return
 
         val scrollDistance = 200
         val endY = scaledY + (vScroll * scrollDistance)
@@ -276,9 +264,7 @@ class ScrcpyControlChannel : DataChannel.Observer {
         service.inputText(text, false)
     }
 
-    private fun scaleCoordinates(x: Int, y: Int, videoW: Int, videoH: Int): Pair<Float, Float> {
-        if (videoW <= 0 || videoH <= 0) return Pair(x.toFloat(), y.toFloat())
-
+    private fun scaleCoordinates(x: Int, y: Int, videoW: Int, videoH: Int): ScreenPoint? {
         val service = MobilerunAccessibilityService.getInstance()
         val wm = service?.getSystemService(android.content.Context.WINDOW_SERVICE) as? android.view.WindowManager
 
@@ -293,10 +279,7 @@ class ScrcpyControlChannel : DataChannel.Observer {
             Pair(metrics.widthPixels, metrics.heightPixels)
         }
 
-        val scaledX = (x.toFloat() / videoW) * screenW
-        val scaledY = (y.toFloat() / videoH) * screenH
-
-        return Pair(scaledX, scaledY)
+        return FrameToScreenMapper.map(x, y, videoW, videoH, screenW, screenH)
     }
 
     private fun dispatchPath(points: List<Pair<Float, Float>>, durationMs: Long) {

--- a/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyTouchInput.kt
+++ b/app/src/main/java/com/mobilerun/portal/streaming/ScrcpyTouchInput.kt
@@ -1,0 +1,214 @@
+package com.mobilerun.portal.streaming
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * The web clients use scrcpy's touch packet shape, but encode the pointer id
+ * in network byte order and the remaining numeric fields in little endian.
+ */
+internal data class ScrcpyTouchPacket(
+    val action: Int,
+    val pointerId: Long,
+    val x: Int,
+    val y: Int,
+    val videoWidth: Int,
+    val videoHeight: Int,
+)
+
+internal object ScrcpyTouchPacketDecoder {
+    const val MESSAGE_TYPE = 2
+    private const val PACKET_SIZE = 32
+
+    fun decode(data: ByteArray): ScrcpyTouchPacket? {
+        if (data.size < PACKET_SIZE || (data[0].toInt() and 0xFF) != MESSAGE_TYPE) {
+            return null
+        }
+
+        val buffer = ByteBuffer.wrap(data)
+        buffer.order(ByteOrder.BIG_ENDIAN)
+        buffer.get()
+        val action = buffer.get().toInt() and 0xFF
+        val pointerId = buffer.long
+
+        buffer.order(ByteOrder.LITTLE_ENDIAN)
+        val x = buffer.int
+        val y = buffer.int
+        val videoWidth = buffer.short.toInt() and 0xFFFF
+        val videoHeight = buffer.short.toInt() and 0xFFFF
+
+        return ScrcpyTouchPacket(
+            action = action,
+            pointerId = pointerId,
+            x = x,
+            y = y,
+            videoWidth = videoWidth,
+            videoHeight = videoHeight,
+        )
+    }
+}
+
+internal object ScrcpyTouchAction {
+    const val DOWN = 0
+    const val UP = 1
+    const val MOVE = 2
+    const val CANCEL = 3
+}
+
+internal data class ScreenPoint(
+    val x: Float,
+    val y: Float,
+)
+
+/**
+ * Inverts MediaProjection's centered, uniform aspect-fit from the display
+ * into the encoded frame. Points in letterbox/pillarbox bars have no display
+ * coordinate and are rejected.
+ */
+internal object FrameToScreenMapper {
+    fun map(
+        x: Int,
+        y: Int,
+        videoWidth: Int,
+        videoHeight: Int,
+        screenWidth: Int,
+        screenHeight: Int,
+    ): ScreenPoint? {
+        if (videoWidth <= 0 || videoHeight <= 0 || screenWidth <= 0 || screenHeight <= 0) {
+            return null
+        }
+
+        val widthScaleProduct = videoWidth.toLong() * screenHeight.toLong()
+        val heightScaleProduct = videoHeight.toLong() * screenWidth.toLong()
+
+        val scale: Double
+        val offsetX: Double
+        val offsetY: Double
+        when {
+            widthScaleProduct == heightScaleProduct -> {
+                scale = videoWidth.toDouble() / screenWidth.toDouble()
+                offsetX = 0.0
+                offsetY = 0.0
+            }
+            widthScaleProduct < heightScaleProduct -> {
+                scale = videoWidth.toDouble() / screenWidth.toDouble()
+                offsetX = 0.0
+                offsetY = (videoHeight.toDouble() - screenHeight.toDouble() * scale) / 2.0
+            }
+            else -> {
+                scale = videoHeight.toDouble() / screenHeight.toDouble()
+                offsetX = (videoWidth.toDouble() - screenWidth.toDouble() * scale) / 2.0
+                offsetY = 0.0
+            }
+        }
+
+        val frameX = x.toDouble()
+        val frameY = y.toDouble()
+        if (frameX < offsetX ||
+            frameX > videoWidth.toDouble() - offsetX ||
+            frameY < offsetY ||
+            frameY > videoHeight.toDouble() - offsetY
+        ) {
+            return null
+        }
+
+        return ScreenPoint(
+            x = ((frameX - offsetX) / scale)
+                .toFloat()
+                .coerceIn(0f, (screenWidth - 1).toFloat()),
+            y = ((frameY - offsetY) / scale)
+                .toFloat()
+                .coerceIn(0f, (screenHeight - 1).toFloat()),
+        )
+    }
+}
+
+internal sealed class TouchGestureUpdate {
+    object Ignored : TouchGestureUpdate()
+
+    data class Started(val point: ScreenPoint) : TouchGestureUpdate()
+
+    data class Moved(val point: ScreenPoint) : TouchGestureUpdate()
+
+    data class Finished(val point: ScreenPoint) : TouchGestureUpdate()
+
+    object Cancelled : TouchGestureUpdate()
+}
+
+/**
+ * Accessibility injection supports one stroke at a time. Latch its pointer id
+ * so interleaved web pointer events cannot reset or splice that stroke.
+ */
+internal class SinglePointerGestureState {
+    var activePointerId: Long? = null
+        private set
+
+    var lastValidPoint: ScreenPoint? = null
+        private set
+
+    fun consume(
+        action: Int,
+        pointerId: Long,
+        mappedPoint: ScreenPoint?,
+    ): TouchGestureUpdate =
+        when (action) {
+            ScrcpyTouchAction.DOWN -> consumeDown(pointerId, mappedPoint)
+            ScrcpyTouchAction.MOVE -> {
+                if (pointerId != activePointerId || mappedPoint == null) {
+                    TouchGestureUpdate.Ignored
+                } else {
+                    lastValidPoint = mappedPoint
+                    TouchGestureUpdate.Moved(mappedPoint)
+                }
+            }
+            ScrcpyTouchAction.UP -> {
+                if (pointerId != activePointerId) {
+                    TouchGestureUpdate.Ignored
+                } else {
+                    val releasePoint = mappedPoint ?: lastValidPoint
+                    clear()
+                    if (releasePoint == null) {
+                        TouchGestureUpdate.Cancelled
+                    } else {
+                        TouchGestureUpdate.Finished(releasePoint)
+                    }
+                }
+            }
+            ScrcpyTouchAction.CANCEL -> {
+                if (pointerId != activePointerId) {
+                    TouchGestureUpdate.Ignored
+                } else {
+                    clear()
+                    TouchGestureUpdate.Cancelled
+                }
+            }
+            else -> TouchGestureUpdate.Ignored
+        }
+
+    private fun consumeDown(
+        pointerId: Long,
+        mappedPoint: ScreenPoint?,
+    ): TouchGestureUpdate {
+        val currentPointerId = activePointerId
+        if (currentPointerId != null && currentPointerId != pointerId) {
+            return TouchGestureUpdate.Ignored
+        }
+
+        if (mappedPoint == null) {
+            if (currentPointerId != null) {
+                clear()
+                return TouchGestureUpdate.Cancelled
+            }
+            return TouchGestureUpdate.Ignored
+        }
+
+        activePointerId = pointerId
+        lastValidPoint = mappedPoint
+        return TouchGestureUpdate.Started(mappedPoint)
+    }
+
+    private fun clear() {
+        activePointerId = null
+        lastValidPoint = null
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
@@ -7,6 +7,7 @@ import android.media.projection.MediaProjectionManager
 import android.os.Bundle
 import android.util.Log
 import com.mobilerun.portal.service.AutoAcceptGate
+import com.mobilerun.portal.service.CaptureSizing
 import com.mobilerun.portal.service.MediaProjectionScreenshotter
 import com.mobilerun.portal.service.ReverseConnectionService
 import com.mobilerun.portal.service.ScreenCaptureService
@@ -24,6 +25,7 @@ class ScreenCaptureActivity : Activity() {
         private const val TAG = "ScreenCaptureActivity"
 
         const val EXTRA_MODE = "mode"
+        const val EXTRA_AUTO_CAPTURE_SIZE = "auto_capture_size"
         const val MODE_STREAM = "stream"
         const val MODE_SCREENSHOT = "screenshot"
     }
@@ -33,8 +35,10 @@ class ScreenCaptureActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mediaProjectionManager = getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-        AutoAcceptGate.armMediaProjection()
-        startActivityForResult(mediaProjectionManager.createScreenCaptureIntent(), REQUEST_CODE_CAPTURE_PERM)
+        if (savedInstanceState == null) {
+            AutoAcceptGate.armMediaProjection()
+            startActivityForResult(mediaProjectionManager.createScreenCaptureIntent(), REQUEST_CODE_CAPTURE_PERM)
+        }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -45,6 +49,15 @@ class ScreenCaptureActivity : Activity() {
                 MediaProjectionScreenshotter.getInstance(this)
                     .onPermissionResult(resultCode, data)
             } else if (resultCode == Activity.RESULT_OK && data != null) {
+                val (captureWidth, captureHeight) =
+                    if (intent.getBooleanExtra(EXTRA_AUTO_CAPTURE_SIZE, false)) {
+                        CaptureSizing.deriveAutoCaptureSize(this)
+                    } else {
+                        Pair(
+                            intent.getIntExtra(ScreenCaptureService.EXTRA_WIDTH, 720),
+                            intent.getIntExtra(ScreenCaptureService.EXTRA_HEIGHT, 1280),
+                        )
+                    }
                 // Pass the permission result to the service
                 val serviceIntent = Intent(this, ScreenCaptureService::class.java).apply {
                     action = ScreenCaptureService.ACTION_PERMISSION_RESULT
@@ -52,8 +65,8 @@ class ScreenCaptureActivity : Activity() {
                     putExtra(ScreenCaptureService.EXTRA_RESULT_CODE, resultCode)
                     putExtra(ScreenCaptureService.EXTRA_RESULT_DATA, data)
                     // Forward stream config from launching intent
-                    putExtra(ScreenCaptureService.EXTRA_WIDTH, intent.getIntExtra(ScreenCaptureService.EXTRA_WIDTH, 720))
-                    putExtra(ScreenCaptureService.EXTRA_HEIGHT, intent.getIntExtra(ScreenCaptureService.EXTRA_HEIGHT, 1280))
+                    putExtra(ScreenCaptureService.EXTRA_WIDTH, captureWidth)
+                    putExtra(ScreenCaptureService.EXTRA_HEIGHT, captureHeight)
                     putExtra(ScreenCaptureService.EXTRA_FPS, intent.getIntExtra(ScreenCaptureService.EXTRA_FPS, 30))
                     putExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, intent.getBooleanExtra(ScreenCaptureService.EXTRA_WAIT_FOR_OFFER, false))
                 }

--- a/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
@@ -13,9 +13,12 @@ import com.mobilerun.portal.input.TextInputResult
 import com.mobilerun.portal.keepalive.KeepAliveController
 import com.mobilerun.portal.keepalive.KeepAliveStartupException
 import com.mobilerun.portal.model.PhoneState
+import com.mobilerun.portal.service.CaptureSizing
 import com.mobilerun.portal.service.MobilerunAccessibilityService
 import com.mobilerun.portal.service.ReverseConnectionService
+import com.mobilerun.portal.service.ScreenCaptureService
 import com.mobilerun.portal.streaming.WebRtcManager
+import com.mobilerun.portal.ui.ScreenCaptureActivity
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.mockk
@@ -613,7 +616,7 @@ class ApiHandlerTest {
     }
 
     @Test
-    fun connectWebRtc_reusesActiveCapture() {
+    fun connectWebRtc_reusesActiveCaptureWithAutoSizeWhenDimensionsAreOmitted() {
         val stateRepo = mockk<StateRepository>(relaxed = true)
         val context = mockk<Context>(relaxed = true)
         every { context.applicationContext } returns context
@@ -623,11 +626,13 @@ class ApiHandlerTest {
 
         mockkObject(WebRtcManager.Companion)
         mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
         every { WebRtcManager.getInstance(context) } returns manager
         every { ReverseConnectionService.getInstance() } returns reverseService
+        every { CaptureSizing.deriveAutoCaptureSize(context) } returns Pair(572, 1280)
         every { manager.isCaptureActive() } returns true
         every {
-            manager.startStreamWithExistingCapture(720, 1280, 30, "session-1", true)
+            manager.startStreamWithExistingCapture(572, 1280, 30, "session-1", true)
         } just Runs
 
         val response =
@@ -642,13 +647,14 @@ class ApiHandlerTest {
         verify(exactly = 1) { manager.setStreamRequestId("session-1") }
         verify(exactly = 1) { manager.setReverseConnectionService(reverseService) }
         verify(exactly = 1) { manager.setPendingIceServers(any()) }
+        verify(exactly = 1) { CaptureSizing.deriveAutoCaptureSize(context) }
         verify(exactly = 1) {
-            manager.startStreamWithExistingCapture(720, 1280, 30, "session-1", true)
+            manager.startStreamWithExistingCapture(572, 1280, 30, "session-1", true)
         }
     }
 
     @Test
-    fun startStream_reusesActiveCaptureAndBindsReverseService() {
+    fun startStream_reusesActiveCaptureWithAutoSizeAndBindsReverseService() {
         val stateRepo = mockk<StateRepository>(relaxed = true)
         val context = mockk<Context>(relaxed = true)
         every { context.applicationContext } returns context
@@ -658,11 +664,13 @@ class ApiHandlerTest {
 
         mockkObject(WebRtcManager.Companion)
         mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
         every { WebRtcManager.getInstance(context) } returns manager
         every { ReverseConnectionService.getInstance() } returns reverseService
+        every { CaptureSizing.deriveAutoCaptureSize(context) } returns Pair(572, 1280)
         every { manager.isCaptureActive() } returns true
         every {
-            manager.startStreamWithExistingCapture(720, 1280, 30, "session-1", false)
+            manager.startStreamWithExistingCapture(572, 1280, 30, "session-1", false)
         } just Runs
 
         val response =
@@ -677,9 +685,160 @@ class ApiHandlerTest {
         verify(exactly = 1) { manager.setStreamRequestId("session-1") }
         verify(exactly = 1) { manager.setReverseConnectionService(reverseService) }
         verify(exactly = 1) { manager.setPendingIceServers(any()) }
+        verify(exactly = 1) { CaptureSizing.deriveAutoCaptureSize(context) }
         verify(exactly = 1) {
-            manager.startStreamWithExistingCapture(720, 1280, 30, "session-1", false)
+            manager.startStreamWithExistingCapture(572, 1280, 30, "session-1", false)
         }
+    }
+
+    @Test
+    fun startStream_preservesLegacyOptIntBehaviorWhenEitherDimensionKeyExists() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns true
+
+        data class Case(
+            val name: String,
+            val params: JSONObject,
+            val expectedWidth: Int,
+            val expectedHeight: Int,
+        )
+
+        val cases =
+            listOf(
+                Case("width-only", JSONObject().put("width", 900), 900, 1280),
+                Case("height-only", JSONObject().put("height", 1600), 720, 1600),
+                Case(
+                    "null",
+                    JSONObject().put("width", JSONObject.NULL).put("height", JSONObject.NULL),
+                    720,
+                    1280,
+                ),
+                Case(
+                    "invalid",
+                    JSONObject().put("width", "bad").put("height", "worse"),
+                    720,
+                    1280,
+                ),
+                Case(
+                    "boolean",
+                    JSONObject().put("width", true).put("height", false),
+                    720,
+                    1280,
+                ),
+                Case("zero", JSONObject().put("width", 0).put("height", 0), 144, 256),
+                Case(
+                    "numeric-string",
+                    JSONObject().put("width", "900").put("height", "1600"),
+                    900,
+                    1600,
+                ),
+                Case(
+                    "explicit",
+                    JSONObject().put("width", 800).put("height", 1400),
+                    800,
+                    1400,
+                ),
+                Case(
+                    "clamped",
+                    JSONObject().put("width", 3000).put("height", 5000),
+                    1920,
+                    3840,
+                ),
+            )
+
+        cases.forEach { case ->
+            val sessionId = "session-${case.name}"
+            case.params.put("sessionId", sessionId)
+
+            assertEquals(
+                case.name,
+                ApiResponse.Success("reusing_capture"),
+                handler.startStream(case.params),
+            )
+            verify(exactly = 1) {
+                manager.startStreamWithExistingCapture(
+                    case.expectedWidth,
+                    case.expectedHeight,
+                    30,
+                    sessionId,
+                    false,
+                )
+            }
+        }
+
+        verify(exactly = 0) { CaptureSizing.deriveAutoCaptureSize(any()) }
+    }
+
+    @Test
+    fun startStream_newCaptureCarriesAutoSizeFlagOnlyWhenBothKeysAreAbsent() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setFlags(any()) } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Int>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<String>())
+        } returns mockk(relaxed = true)
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns false
+
+        assertEquals(
+            ApiResponse.Success("prompting_user"),
+            handler.startStream(JSONObject().put("sessionId", "session-auto")),
+        )
+        assertEquals(
+            ApiResponse.Success("prompting_user"),
+            handler.startStream(
+                JSONObject()
+                    .put("sessionId", "session-explicit")
+                    .put("width", 900)
+                    .put("height", 1600),
+            ),
+        )
+
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_AUTO_CAPTURE_SIZE, true)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_AUTO_CAPTURE_SIZE, false)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_WIDTH, 720)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_HEIGHT, 1280)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_WIDTH, 900)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_HEIGHT, 1600)
+        }
+        verify(exactly = 0) { CaptureSizing.deriveAutoCaptureSize(any()) }
+        verify(exactly = 2) { context.startActivity(any()) }
     }
 
     @Test

--- a/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
@@ -1,0 +1,80 @@
+package com.mobilerun.portal.service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CaptureSizingTest {
+    @Test
+    fun deriveAutoCaptureSize_aspectFitsCommonScreenSizes() {
+        val cases =
+            listOf(
+                SizingCase("tall portrait", 1280, 2856, 572 to 1280),
+                SizingCase("wide landscape", 2856, 1280, 720 to 322),
+                SizingCase("two-to-one portrait", 1080, 2160, 640 to 1280),
+            )
+
+        cases.forEach { case ->
+            assertEquals(
+                case.name,
+                case.expected,
+                CaptureSizing.deriveAutoCaptureSize(case.screenWidth, case.screenHeight),
+            )
+        }
+    }
+
+    @Test
+    fun deriveAutoCaptureSize_handlesExactNineBySixteenWithoutRoundingLoss() {
+        val cases =
+            listOf(
+                SizingCase("PR regression dimensions", 1386, 2464, 720 to 1280),
+                SizingCase("standard FHD dimensions", 1080, 1920, 720 to 1280),
+                SizingCase("QHD dimensions", 1440, 2560, 720 to 1280),
+            )
+
+        cases.forEach { case ->
+            assertEquals(
+                case.name,
+                case.expected,
+                CaptureSizing.deriveAutoCaptureSize(case.screenWidth, case.screenHeight),
+            )
+        }
+    }
+
+    @Test
+    fun deriveAutoCaptureSize_doesNotUpscaleAndFloorsToEven() {
+        assertEquals(
+            700 to 1000,
+            CaptureSizing.deriveAutoCaptureSize(screenWidth = 701, screenHeight = 1001),
+        )
+    }
+
+    @Test
+    fun deriveAutoCaptureSize_fallsBackWholesaleForInvalidOrOutOfBoundsFits() {
+        val fallback =
+            CaptureSizing.DEFAULT_CAPTURE_WIDTH to CaptureSizing.DEFAULT_CAPTURE_HEIGHT
+        val cases =
+            listOf(
+                SizingCase("zero width", 0, 1000, fallback),
+                SizingCase("negative height", 1000, -1, fallback),
+                SizingCase("undersized screen", 200, 200, fallback),
+                SizingCase("too wide", 3000, 1000, fallback),
+                SizingCase("too tall", 1000, 10000, fallback),
+                SizingCase("extreme integer aspect", Int.MAX_VALUE, 1, fallback),
+            )
+
+        cases.forEach { case ->
+            assertEquals(
+                case.name,
+                case.expected,
+                CaptureSizing.deriveAutoCaptureSize(case.screenWidth, case.screenHeight),
+            )
+        }
+    }
+
+    private data class SizingCase(
+        val name: String,
+        val screenWidth: Int,
+        val screenHeight: Int,
+        val expected: Pair<Int, Int>,
+    )
+}

--- a/app/src/test/java/com/mobilerun/portal/streaming/ScrcpyTouchInputTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/streaming/ScrcpyTouchInputTest.kt
@@ -1,0 +1,416 @@
+package com.mobilerun.portal.streaming
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class ScrcpyTouchInputTest {
+    @Test
+    fun decoder_readsMixedEndianPointerAndPositionFields() {
+        val packet =
+            touchPacket(
+                action = ScrcpyTouchAction.CANCEL,
+                pointerId = 0x0102030405060708L,
+                x = -123_456_789,
+                y = 987_654_321,
+                videoWidth = 65_535,
+                videoHeight = 3_840,
+            )
+
+        assertEquals(
+            ScrcpyTouchPacket(
+                action = ScrcpyTouchAction.CANCEL,
+                pointerId = 0x0102030405060708L,
+                x = -123_456_789,
+                y = 987_654_321,
+                videoWidth = 65_535,
+                videoHeight = 3_840,
+            ),
+            ScrcpyTouchPacketDecoder.decode(packet),
+        )
+    }
+
+    @Test
+    fun decoder_preservesMousePointerIdAndIgnoresTrailingFields() {
+        val decoded =
+            ScrcpyTouchPacketDecoder.decode(
+                touchPacket(
+                    action = ScrcpyTouchAction.DOWN,
+                    pointerId = -1L,
+                    x = 17,
+                    y = 29,
+                    videoWidth = 720,
+                    videoHeight = 1_280,
+                ),
+            )
+
+        assertNotNull(decoded)
+        assertEquals(-1L, decoded?.pointerId)
+    }
+
+    @Test
+    fun decoder_rejectsWrongMessageTypeAndTruncatedPackets() {
+        val wrongType =
+            touchPacket(
+                action = ScrcpyTouchAction.DOWN,
+                pointerId = 1L,
+                x = 0,
+                y = 0,
+                videoWidth = 720,
+                videoHeight = 1_280,
+            ).also {
+                it[0] = 3
+            }
+
+        assertNull(ScrcpyTouchPacketDecoder.decode(wrongType))
+        assertNull(ScrcpyTouchPacketDecoder.decode(ByteArray(0)))
+        assertNull(ScrcpyTouchPacketDecoder.decode(ByteArray(31)))
+    }
+
+    @Test
+    fun mapper_handlesPillarboxContentBarsAndBoundaries() {
+        val center =
+            FrameToScreenMapper.map(
+                x = 360,
+                y = 640,
+                videoWidth = 720,
+                videoHeight = 1_280,
+                screenWidth = 1_080,
+                screenHeight = 2_400,
+            )
+        val topLeft =
+            FrameToScreenMapper.map(
+                x = 72,
+                y = 0,
+                videoWidth = 720,
+                videoHeight = 1_280,
+                screenWidth = 1_080,
+                screenHeight = 2_400,
+            )
+        val bottomRight =
+            FrameToScreenMapper.map(
+                x = 648,
+                y = 1_280,
+                videoWidth = 720,
+                videoHeight = 1_280,
+                screenWidth = 1_080,
+                screenHeight = 2_400,
+            )
+
+        assertPoint(center, 540f, 1_200f)
+        assertPoint(topLeft, 0f, 0f)
+        assertPoint(bottomRight, 1_079f, 2_399f)
+        assertNull(
+            FrameToScreenMapper.map(71, 640, 720, 1_280, 1_080, 2_400),
+        )
+        assertNull(
+            FrameToScreenMapper.map(649, 640, 720, 1_280, 1_080, 2_400),
+        )
+    }
+
+    @Test
+    fun mapper_handlesApi29PillarboxGeometry() {
+        assertPoint(
+            FrameToScreenMapper.map(40, 0, 720, 1_280, 1_080, 2_160),
+            expectedX = 0f,
+            expectedY = 0f,
+        )
+        assertPoint(
+            FrameToScreenMapper.map(680, 1_280, 720, 1_280, 1_080, 2_160),
+            expectedX = 1_079f,
+            expectedY = 2_159f,
+        )
+        assertNull(FrameToScreenMapper.map(39, 640, 720, 1_280, 1_080, 2_160))
+    }
+
+    @Test
+    fun mapper_handlesLandscapeLetterboxGeometry() {
+        assertPoint(
+            FrameToScreenMapper.map(640, 72, 1_280, 720, 2_400, 1_080),
+            expectedX = 1_200f,
+            expectedY = 0f,
+        )
+        assertPoint(
+            FrameToScreenMapper.map(1_280, 648, 1_280, 720, 2_400, 1_080),
+            expectedX = 2_399f,
+            expectedY = 1_079f,
+        )
+        assertNull(FrameToScreenMapper.map(640, 71, 1_280, 720, 2_400, 1_080))
+        assertNull(FrameToScreenMapper.map(640, 649, 1_280, 720, 2_400, 1_080))
+    }
+
+    @Test
+    fun mapper_exactAspectAndLimitingAxesHaveExactZeroOffset() {
+        assertPoint(
+            FrameToScreenMapper.map(0, 0, 720, 1_280, 1_080, 1_920),
+            expectedX = 0f,
+            expectedY = 0f,
+        )
+        assertNotNull(
+            FrameToScreenMapper.map(360, 0, 720, 1_280, 1_080, 2_408),
+        )
+        assertNotNull(
+            FrameToScreenMapper.map(0, 360, 1_280, 720, 2_408, 1_080),
+        )
+    }
+
+    @Test
+    fun mapper_clampsInclusiveFrameEdges() {
+        assertPoint(
+            FrameToScreenMapper.map(720, 1_280, 720, 1_280, 720, 1_280),
+            expectedX = 719f,
+            expectedY = 1_279f,
+        )
+    }
+
+    @Test
+    fun mapper_rejectsInvalidDimensionsAndOutOfFrameCoordinates() {
+        val invalidDimensions =
+            listOf(
+                intArrayOf(0, 1_280, 720, 1_280),
+                intArrayOf(720, 0, 720, 1_280),
+                intArrayOf(720, 1_280, 0, 1_280),
+                intArrayOf(720, 1_280, 720, 0),
+                intArrayOf(-720, 1_280, 720, 1_280),
+                intArrayOf(720, -1_280, 720, 1_280),
+                intArrayOf(720, 1_280, -720, 1_280),
+                intArrayOf(720, 1_280, 720, -1_280),
+            )
+
+        for ((videoWidth, videoHeight, screenWidth, screenHeight) in invalidDimensions) {
+            assertNull(
+                FrameToScreenMapper.map(
+                    x = 0,
+                    y = 0,
+                    videoWidth = videoWidth,
+                    videoHeight = videoHeight,
+                    screenWidth = screenWidth,
+                    screenHeight = screenHeight,
+                ),
+            )
+        }
+
+        assertNull(FrameToScreenMapper.map(-1, 0, 720, 1_280, 720, 1_280))
+        assertNull(FrameToScreenMapper.map(0, -1, 720, 1_280, 720, 1_280))
+        assertNull(FrameToScreenMapper.map(721, 0, 720, 1_280, 720, 1_280))
+        assertNull(FrameToScreenMapper.map(0, 1_281, 720, 1_280, 720, 1_280))
+    }
+
+    @Test
+    fun mapper_crossProductsDoNotOverflowForExtremePositiveDimensions() {
+        assertNotNull(
+            FrameToScreenMapper.map(
+                x = 1_000_000_000,
+                y = 1_000_000_000,
+                videoWidth = Int.MAX_VALUE,
+                videoHeight = Int.MAX_VALUE,
+                screenWidth = Int.MAX_VALUE,
+                screenHeight = Int.MAX_VALUE,
+            ),
+        )
+    }
+
+    @Test
+    fun pointerState_tracksNormalGestureAndReleasesOwnership() {
+        val state = SinglePointerGestureState()
+        val down = ScreenPoint(10f, 20f)
+        val move = ScreenPoint(30f, 40f)
+        val up = ScreenPoint(50f, 60f)
+
+        assertEquals(TouchGestureUpdate.Started(down), state.consume(0, 11L, down))
+        assertEquals(11L, state.activePointerId)
+        assertEquals(TouchGestureUpdate.Moved(move), state.consume(2, 11L, move))
+        assertEquals(move, state.lastValidPoint)
+        assertEquals(TouchGestureUpdate.Finished(up), state.consume(1, 11L, up))
+        assertNull(state.activePointerId)
+        assertNull(state.lastValidPoint)
+    }
+
+    @Test
+    fun pointerState_ignoresForeignPointerWithoutCorruptingOwner() {
+        val state = SinglePointerGestureState()
+        val ownerDown = ScreenPoint(10f, 20f)
+        val ownerMove = ScreenPoint(30f, 40f)
+        val foreignPoint = ScreenPoint(100f, 200f)
+
+        state.consume(ScrcpyTouchAction.DOWN, 1L, ownerDown)
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.DOWN, 2L, foreignPoint),
+        )
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.MOVE, 2L, foreignPoint),
+        )
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.UP, 2L, foreignPoint),
+        )
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.CANCEL, 2L, null),
+        )
+
+        assertEquals(1L, state.activePointerId)
+        assertEquals(
+            TouchGestureUpdate.Moved(ownerMove),
+            state.consume(ScrcpyTouchAction.MOVE, 1L, ownerMove),
+        )
+        assertEquals(
+            TouchGestureUpdate.Finished(ownerMove),
+            state.consume(ScrcpyTouchAction.UP, 1L, null),
+        )
+    }
+
+    @Test
+    fun pointerState_dropsBarDownAndSkipsBarMove() {
+        val state = SinglePointerGestureState()
+        val down = ScreenPoint(10f, 20f)
+
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.DOWN, 1L, null),
+        )
+        assertNull(state.activePointerId)
+
+        state.consume(ScrcpyTouchAction.DOWN, 1L, down)
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.MOVE, 1L, null),
+        )
+        assertEquals(down, state.lastValidPoint)
+    }
+
+    @Test
+    fun pointerState_barUpReleasesAtLastValidPoint() {
+        val state = SinglePointerGestureState()
+        val lastInside = ScreenPoint(300f, 400f)
+
+        state.consume(ScrcpyTouchAction.DOWN, 1L, ScreenPoint(10f, 20f))
+        state.consume(ScrcpyTouchAction.MOVE, 1L, lastInside)
+
+        assertEquals(
+            TouchGestureUpdate.Finished(lastInside),
+            state.consume(ScrcpyTouchAction.UP, 1L, null),
+        )
+        assertNull(state.activePointerId)
+    }
+
+    @Test
+    fun pointerState_matchingCancelClearsGestureAndAllowsNewDown() {
+        val state = SinglePointerGestureState()
+        val first = ScreenPoint(10f, 20f)
+        val second = ScreenPoint(30f, 40f)
+
+        state.consume(ScrcpyTouchAction.DOWN, 1L, first)
+        assertSame(
+            TouchGestureUpdate.Cancelled,
+            state.consume(ScrcpyTouchAction.CANCEL, 1L, null),
+        )
+        assertNull(state.activePointerId)
+        assertEquals(
+            TouchGestureUpdate.Started(second),
+            state.consume(ScrcpyTouchAction.DOWN, 2L, second),
+        )
+    }
+
+    @Test
+    fun pointerState_samePointerDownRestartsOrCancelsItsGesture() {
+        val state = SinglePointerGestureState()
+        val first = ScreenPoint(10f, 20f)
+        val replacement = ScreenPoint(30f, 40f)
+
+        state.consume(ScrcpyTouchAction.DOWN, 1L, first)
+        assertEquals(
+            TouchGestureUpdate.Started(replacement),
+            state.consume(ScrcpyTouchAction.DOWN, 1L, replacement),
+        )
+        assertEquals(replacement, state.lastValidPoint)
+        assertSame(
+            TouchGestureUpdate.Cancelled,
+            state.consume(ScrcpyTouchAction.DOWN, 1L, null),
+        )
+        assertNull(state.activePointerId)
+    }
+
+    @Test
+    fun pointerState_ignoresOrphanAndUnknownEvents() {
+        val state = SinglePointerGestureState()
+        val point = ScreenPoint(10f, 20f)
+
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.MOVE, 1L, point),
+        )
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.UP, 1L, point),
+        )
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.CANCEL, 1L, null),
+        )
+        assertSame(TouchGestureUpdate.Ignored, state.consume(99, 1L, point))
+    }
+
+    @Test
+    fun invalidFrameDimensionsNeverLatchPointer() {
+        val state = SinglePointerGestureState()
+        val mapped =
+            FrameToScreenMapper.map(
+                x = 10,
+                y = 20,
+                videoWidth = 0,
+                videoHeight = 1_280,
+                screenWidth = 720,
+                screenHeight = 1_280,
+            )
+
+        assertSame(
+            TouchGestureUpdate.Ignored,
+            state.consume(ScrcpyTouchAction.DOWN, 1L, mapped),
+        )
+        assertNull(state.activePointerId)
+    }
+
+    private fun assertPoint(
+        actual: ScreenPoint?,
+        expectedX: Float,
+        expectedY: Float,
+        tolerance: Float = 0.01f,
+    ) {
+        assertNotNull(actual)
+        requireNotNull(actual)
+        assertEquals(expectedX, actual.x, tolerance)
+        assertEquals(expectedY, actual.y, tolerance)
+    }
+
+    private fun touchPacket(
+        action: Int,
+        pointerId: Long,
+        x: Int,
+        y: Int,
+        videoWidth: Int,
+        videoHeight: Int,
+    ): ByteArray {
+        val buffer = ByteBuffer.allocate(32)
+        buffer.order(ByteOrder.BIG_ENDIAN)
+        buffer.put(ScrcpyTouchPacketDecoder.MESSAGE_TYPE.toByte())
+        buffer.put(action.toByte())
+        buffer.putLong(pointerId)
+
+        buffer.order(ByteOrder.LITTLE_ENDIAN)
+        buffer.putInt(x)
+        buffer.putInt(y)
+        buffer.putShort(videoWidth.toShort())
+        buffer.putShort(videoHeight.toShort())
+        buffer.putShort(0xFFFF.toShort())
+        buffer.putInt(0x01020304)
+        buffer.putInt(0x05060708)
+        return buffer.array()
+    }
+}


### PR DESCRIPTION
## Summary

This completes the BYO streaming fix that began with missing capture dimensions and now also corrects WebRTC control input whenever the encoded frame and display have different aspect ratios.

Capture sizing:

- automatic sizing is selected only when both width and height keys are absent
- the current display is aspect-fit inside 720×1280 without upscaling, using Long arithmetic and even derived dimensions
- active reuse resolves immediately; new MediaProjection captures resolve after permission in the current orientation
- partial, null, invalid, boolean, numeric-string, zero, explicit, and clamped requests preserve the prior optInt behavior

Remote input:

- touch packets decode the mixed-endian 64-bit pointer ID used by both web clients
- touch and scroll uniformly invert centered letterbox/pillarbox projection
- points in bars or with invalid dimensions are rejected; valid content edges clamp to screen bounds
- one pointer owns the accessibility gesture; foreign pointers cannot reset or splice it
- bar MOVE is ignored, bar UP releases at the last valid point, and CANCEL discards the buffered path without creating a tap

The RPC schema, explicit capture dimensions, ScreenCaptureService, and wire format are unchanged. This PR now supersedes the complete relevant scope of closed #152. Credit to @lutz-grex for identifying the BYO rendering problem and proposing the original fix. Internal counterpart: droidrun/mobilerun-portal-internal#74.

## Validation

- Focused JVM tests (sizing, request compatibility, decoder/mapper/gesture): 65/65 passed
- Full JVM suite: 506/507 passed; the only failure is the documented baseline SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates
- app assembleDebug: passed
- Connected instrumentation: API 36 5/5, API 35 5/5, API 34 5/5

Real reverse-WebSocket/WebRTC/control E2E:

- API 36, 35, and 34: omitted portrait and active reuse 576×1280; explicit/null/invalid 720×1280; ICE, RTP, and control connected
- API 36 and 35: rotate while permission is pending, reselect full-screen after Android recreates the selector, exactly one start/result, 720×324
- API 34: the system selector returns one cancellation when its open prompt rotates; the app reports permission_denied once, and a fresh landscape retry streams 720×324
- API 29 and 26 on 1080×2160: omitted 640×1280 and explicit 720×1280 with VP8/RTP/control connected
- All tested versions: center and flush content edges map correctly; bar taps/scrolls are rejected; foreign pointers are isolated; DOWN → CANCEL produces no tap and a new pointer succeeds
- Stale-orientation explicit 720×1280 input was verified in landscape

No supplied API key was read or needed.