### PR TITLE
feat(stream): scrcpy-style maxWidth/maxHeight bounding-box capture params

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -109,23 +109,45 @@ class ApiHandler(
         val width: Int,
         val height: Int,
         val auto: Boolean,
+        val maxWidth: Int? = null,
+        val maxHeight: Int? = null,
     ) {
         fun resolve(context: Context): Pair<Int, Int> =
-            if (auto) {
-                CaptureSizing.deriveAutoCaptureSize(context)
-            } else {
-                Pair(width, height)
+            when {
+                maxWidth != null && maxHeight != null ->
+                    CaptureSizing.deriveCapCaptureSize(context, maxWidth, maxHeight)
+                auto -> CaptureSizing.deriveAutoCaptureSize(context)
+                else -> Pair(width, height)
             }
     }
 
-    private fun selectCaptureSize(params: JSONObject): CaptureSizeSelection =
-        CaptureSizeSelection(
+    /**
+     * A `maxWidth`/`maxHeight` pair activates bounding-box mode and takes
+     * precedence over `width`/`height`. The pair must be fully present and
+     * positive; a partial pair or non-positive value is treated as absent
+     * and falls through to the legacy explicit/auto behavior.
+     */
+    private fun selectCaptureSize(params: JSONObject): CaptureSizeSelection {
+        val maxWidth = params.optInt("maxWidth", 0)
+        val maxHeight = params.optInt("maxHeight", 0)
+        if (maxWidth > 0 && maxHeight > 0) {
+            return CaptureSizeSelection(
+                width = CaptureSizing.DEFAULT_CAPTURE_WIDTH,
+                height = CaptureSizing.DEFAULT_CAPTURE_HEIGHT,
+                auto = false,
+                maxWidth = maxWidth,
+                maxHeight = maxHeight,
+            )
+        }
+
+        return CaptureSizeSelection(
             width = params.optInt("width", CaptureSizing.DEFAULT_CAPTURE_WIDTH)
                 .coerceIn(CaptureSizing.CAPTURE_WIDTH_MIN, CaptureSizing.CAPTURE_WIDTH_MAX),
             height = params.optInt("height", CaptureSizing.DEFAULT_CAPTURE_HEIGHT)
                 .coerceIn(CaptureSizing.CAPTURE_HEIGHT_MIN, CaptureSizing.CAPTURE_HEIGHT_MAX),
             auto = !params.has("width") && !params.has("height"),
         )
+    }
 
     private fun getAvailableInternalBytes(): Long? {
         return try {
@@ -1991,6 +2013,12 @@ class ApiHandler(
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
                 putExtra(ScreenCaptureActivity.EXTRA_MODE, ScreenCaptureActivity.MODE_STREAM)
                 putExtra(ScreenCaptureActivity.EXTRA_AUTO_CAPTURE_SIZE, captureSize.auto)
+                captureSize.maxWidth?.let {
+                    putExtra(ScreenCaptureActivity.EXTRA_MAX_WIDTH, it)
+                }
+                captureSize.maxHeight?.let {
+                    putExtra(ScreenCaptureActivity.EXTRA_MAX_HEIGHT, it)
+                }
                 putExtra(ScreenCaptureService.EXTRA_WIDTH, captureSize.width)
                 putExtra(ScreenCaptureService.EXTRA_HEIGHT, captureSize.height)
                 putExtra(ScreenCaptureService.EXTRA_FPS, fps)

--- a/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/CaptureSizing.kt
@@ -27,43 +27,42 @@ internal object CaptureSizing {
         Pair(DEFAULT_CAPTURE_WIDTH, DEFAULT_CAPTURE_HEIGHT)
 
     /**
-     * Aspect-fits the screen into the legacy capture box without upscaling.
+     * Aspect-fits the screen into an arbitrary capture box without upscaling.
      *
      * Cross-products and integer division avoid floating-point underflow at
      * exact aspect ratios. A result outside the existing stream bounds is
-     * rejected wholesale instead of clamping one axis and distorting it.
+     * rejected wholesale instead of clamping one axis and distorting it. The
+     * result never exceeds the box in either dimension.
      */
     fun fitCaptureSizeToScreen(
         screenWidth: Int,
         screenHeight: Int,
+        boxWidth: Int = DEFAULT_CAPTURE_WIDTH,
+        boxHeight: Int = DEFAULT_CAPTURE_HEIGHT,
     ): Pair<Int, Int>? {
-        if (screenWidth <= 0 || screenHeight <= 0) return null
+        if (screenWidth <= 0 || screenHeight <= 0 || boxWidth <= 0 || boxHeight <= 0) return null
 
         val fittedWidth: Long
         val fittedHeight: Long
-        if (
-            screenWidth <= DEFAULT_CAPTURE_WIDTH &&
-            screenHeight <= DEFAULT_CAPTURE_HEIGHT
-        ) {
+        if (screenWidth <= boxWidth && screenHeight <= boxHeight) {
             fittedWidth = floorToEven(screenWidth.toLong())
             fittedHeight = floorToEven(screenHeight.toLong())
         } else {
             val widthIsLimiting =
-                DEFAULT_CAPTURE_WIDTH.toLong() * screenHeight <=
-                    DEFAULT_CAPTURE_HEIGHT.toLong() * screenWidth
+                boxWidth.toLong() * screenHeight <= boxHeight.toLong() * screenWidth
 
             if (widthIsLimiting) {
-                fittedWidth = DEFAULT_CAPTURE_WIDTH.toLong()
+                fittedWidth = floorToEven(boxWidth.toLong())
                 fittedHeight =
                     floorToEven(
-                        screenHeight.toLong() * DEFAULT_CAPTURE_WIDTH / screenWidth,
+                        screenHeight.toLong() * boxWidth / screenWidth,
                     )
             } else {
                 fittedWidth =
                     floorToEven(
-                        screenWidth.toLong() * DEFAULT_CAPTURE_HEIGHT / screenHeight,
+                        screenWidth.toLong() * boxHeight / screenHeight,
                     )
-                fittedHeight = DEFAULT_CAPTURE_HEIGHT.toLong()
+                fittedHeight = floorToEven(boxHeight.toLong())
             }
         }
 
@@ -90,6 +89,25 @@ internal object CaptureSizing {
     fun deriveAutoCaptureSize(context: Context): Pair<Int, Int> {
         val screenSize = readDisplaySize(context) ?: return legacyCaptureSize
         return deriveAutoCaptureSize(screenSize.first, screenSize.second)
+    }
+
+    /**
+     * Resolves the current screen size aspect-fitted into [maxWidth]x[maxHeight].
+     *
+     * Falls back to the default-box auto size if display lookup fails or the
+     * fit is rejected, never returning a distorted or out-of-bounds size and
+     * never falling back to the raw cap values. An unusable cap (e.g. below
+     * the supported capture minima) is treated as absent, so the fallback may
+     * exceed the requested box — stream start must not fail on a bad cap.
+     */
+    fun deriveCapCaptureSize(
+        context: Context,
+        maxWidth: Int,
+        maxHeight: Int,
+    ): Pair<Int, Int> {
+        val screenSize = readDisplaySize(context) ?: return deriveAutoCaptureSize(context)
+        return fitCaptureSizeToScreen(screenSize.first, screenSize.second, maxWidth, maxHeight)
+            ?: deriveAutoCaptureSize(context)
     }
 
     fun readDisplaySize(context: Context): Pair<Int, Int>? {

--- a/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/ScreenCaptureActivity.kt
@@ -26,6 +26,8 @@ class ScreenCaptureActivity : Activity() {
 
         const val EXTRA_MODE = "mode"
         const val EXTRA_AUTO_CAPTURE_SIZE = "auto_capture_size"
+        const val EXTRA_MAX_WIDTH = "max_width"
+        const val EXTRA_MAX_HEIGHT = "max_height"
         const val MODE_STREAM = "stream"
         const val MODE_SCREENSHOT = "screenshot"
     }
@@ -50,7 +52,13 @@ class ScreenCaptureActivity : Activity() {
                     .onPermissionResult(resultCode, data)
             } else if (resultCode == Activity.RESULT_OK && data != null) {
                 val (captureWidth, captureHeight) =
-                    if (intent.getBooleanExtra(EXTRA_AUTO_CAPTURE_SIZE, false)) {
+                    if (intent.hasExtra(EXTRA_MAX_WIDTH) && intent.hasExtra(EXTRA_MAX_HEIGHT)) {
+                        CaptureSizing.deriveCapCaptureSize(
+                            this,
+                            intent.getIntExtra(EXTRA_MAX_WIDTH, 0),
+                            intent.getIntExtra(EXTRA_MAX_HEIGHT, 0),
+                        )
+                    } else if (intent.getBooleanExtra(EXTRA_AUTO_CAPTURE_SIZE, false)) {
                         CaptureSizing.deriveAutoCaptureSize(this)
                     } else {
                         Pair(

--- a/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
@@ -842,6 +842,211 @@ class ApiHandlerTest {
     }
 
     @Test
+    fun startStream_capModeActivatesOnlyWhenBothMaxDimsPresentAndPositive() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns true
+        every { CaptureSizing.deriveAutoCaptureSize(context) } returns Pair(572, 1280)
+        every { CaptureSizing.deriveCapCaptureSize(context, 400, 800) } returns Pair(500, 900)
+        every { CaptureSizing.deriveCapCaptureSize(context, 410, 810) } returns Pair(510, 910)
+        every { CaptureSizing.deriveCapCaptureSize(context, 420, 820) } returns Pair(520, 920)
+
+        data class Case(
+            val name: String,
+            val params: JSONObject,
+            val sessionId: String,
+            val expectedWidth: Int,
+            val expectedHeight: Int,
+        )
+
+        val cases =
+            listOf(
+                Case(
+                    "both positive activates cap mode",
+                    JSONObject().put("maxWidth", 400).put("maxHeight", 800),
+                    "session-cap-both",
+                    500,
+                    900,
+                ),
+                Case(
+                    "maxWidth only is a partial pair, falls to auto",
+                    JSONObject().put("maxWidth", 400),
+                    "session-cap-width-only",
+                    572,
+                    1280,
+                ),
+                Case(
+                    "maxHeight only is a partial pair, falls to auto",
+                    JSONObject().put("maxHeight", 800),
+                    "session-cap-height-only",
+                    572,
+                    1280,
+                ),
+                Case(
+                    "zero maxWidth treated as absent",
+                    JSONObject().put("maxWidth", 0).put("maxHeight", 800),
+                    "session-cap-zero-width",
+                    572,
+                    1280,
+                ),
+                Case(
+                    "negative maxHeight treated as absent",
+                    JSONObject().put("maxWidth", 400).put("maxHeight", -1),
+                    "session-cap-negative-height",
+                    572,
+                    1280,
+                ),
+                Case(
+                    "non-numeric strings treated as absent",
+                    JSONObject().put("maxWidth", "bad").put("maxHeight", "worse"),
+                    "session-cap-invalid-strings",
+                    572,
+                    1280,
+                ),
+                Case(
+                    "numeric strings activate cap mode",
+                    JSONObject().put("maxWidth", "410").put("maxHeight", "810"),
+                    "session-cap-numeric-strings",
+                    510,
+                    910,
+                ),
+                Case(
+                    "cap mode takes precedence over explicit width/height",
+                    JSONObject()
+                        .put("maxWidth", 420)
+                        .put("maxHeight", 820)
+                        .put("width", 900)
+                        .put("height", 1600),
+                    "session-cap-precedence",
+                    520,
+                    920,
+                ),
+            )
+
+        cases.forEach { case ->
+            case.params.put("sessionId", case.sessionId)
+            assertEquals(
+                case.name,
+                ApiResponse.Success("reusing_capture"),
+                handler.startStream(case.params),
+            )
+            verify(exactly = 1) {
+                manager.startStreamWithExistingCapture(
+                    case.expectedWidth,
+                    case.expectedHeight,
+                    30,
+                    case.sessionId,
+                    false,
+                )
+            }
+        }
+
+        verify(exactly = 3) { CaptureSizing.deriveCapCaptureSize(context, any(), any()) }
+    }
+
+    @Test
+    fun startStream_newCaptureCarriesMaxDimsExtrasWhenCapModeActive() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setFlags(any()) } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Int>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<String>())
+        } returns mockk(relaxed = true)
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        mockkObject(CaptureSizing)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns false
+
+        assertEquals(
+            ApiResponse.Success("prompting_user"),
+            handler.startStream(
+                JSONObject()
+                    .put("sessionId", "session-cap-new")
+                    .put("maxWidth", 400)
+                    .put("maxHeight", 800),
+            ),
+        )
+
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_MAX_WIDTH, 400)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_MAX_HEIGHT, 800)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_AUTO_CAPTURE_SIZE, false)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_WIDTH, 720)
+        }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureService.EXTRA_HEIGHT, 1280)
+        }
+        verify(exactly = 0) { CaptureSizing.deriveAutoCaptureSize(any()) }
+        verify(exactly = 1) { context.startActivity(any()) }
+    }
+
+    @Test
+    fun startStream_newCaptureOmitsMaxDimsExtrasWhenCapModeInactive() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+        val manager = mockk<WebRtcManager>(relaxed = true)
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().setFlags(any()) } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Boolean>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<Int>())
+        } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().putExtra(any<String>(), any<String>())
+        } returns mockk(relaxed = true)
+        mockkObject(WebRtcManager.Companion)
+        mockkObject(ReverseConnectionService.Companion)
+        every { WebRtcManager.getInstance(context) } returns manager
+        every { ReverseConnectionService.getInstance() } returns null
+        every { manager.isCaptureActive() } returns false
+
+        assertEquals(
+            ApiResponse.Success("prompting_user"),
+            handler.startStream(JSONObject().put("sessionId", "session-no-cap")),
+        )
+
+        verify(exactly = 0) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_MAX_WIDTH, any<Int>())
+        }
+        verify(exactly = 0) {
+            anyConstructed<Intent>().putExtra(ScreenCaptureActivity.EXTRA_MAX_HEIGHT, any<Int>())
+        }
+    }
+
+    @Test
     fun connectWebRtc_withoutActiveCapture_fallsBackToStartStream() {
         val stateRepo = mockk<StateRepository>(relaxed = true)
         val context = mockk<Context>(relaxed = true)

--- a/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/CaptureSizingTest.kt
@@ -1,6 +1,7 @@
 package com.mobilerun.portal.service
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CaptureSizingTest {
@@ -71,10 +72,132 @@ class CaptureSizingTest {
         }
     }
 
+    @Test
+    fun fitCaptureSizeToScreen_fitsIntoArbitraryBoxWithoutUpscale() {
+        val cases =
+            listOf(
+                BoxCase("cap smaller than screen", 1080, 1920, 400, 800, 400 to 710),
+                BoxCase("cap larger than screen, no upscale", 300, 500, 720, 1280, 300 to 500),
+                BoxCase("landscape box", 1920, 1080, 1024, 600, 1024 to 576),
+            )
+
+        cases.forEach { case ->
+            assertEquals(
+                case.name,
+                case.expected,
+                CaptureSizing.fitCaptureSizeToScreen(
+                    case.screenWidth,
+                    case.screenHeight,
+                    case.boxWidth,
+                    case.boxHeight,
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun fitCaptureSizeToScreen_boundaryJustBelowHeightMinIsRejected() {
+        // Landscape screen fitted height-limited into a 256-tall box lands
+        // exactly on CAPTURE_HEIGHT_MIN: accepted.
+        assertEquals(
+            454 to 256,
+            CaptureSizing.fitCaptureSizeToScreen(1920, 1080, 3840, 256),
+        )
+
+        // One pixel shorter drops the fitted height just below
+        // CAPTURE_HEIGHT_MIN once floored to even: rejected wholesale.
+        assertEquals(
+            null,
+            CaptureSizing.fitCaptureSizeToScreen(1920, 1080, 3840, 255),
+        )
+    }
+
+    @Test
+    fun fitCaptureSizeToScreen_boundaryJustBelowWidthMinIsRejected() {
+        // Portrait screen width-limited into a 144-wide box lands exactly on
+        // CAPTURE_WIDTH_MIN: accepted.
+        assertEquals(
+            144 to 256,
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920, 144, 3840),
+        )
+
+        // One pixel narrower drops the fitted width just below
+        // CAPTURE_WIDTH_MIN once floored to even: rejected wholesale.
+        assertEquals(
+            null,
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920, 143, 3840),
+        )
+    }
+
+    @Test
+    fun fitCaptureSizeToScreen_rejectsWholesaleWhenFitFallsOutsideBounds() {
+        assertEquals(
+            null,
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920, 100, 3840),
+        )
+        assertEquals(
+            null,
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920, 1920, 100),
+        )
+        assertEquals(
+            null,
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920, 0, 100),
+        )
+    }
+
+    @Test
+    fun fitCaptureSizeToScreen_resultNeverExceedsBoxAndIsEvenAndInBounds() {
+        val boxes =
+            listOf(
+                Triple(1080, 1920, 400 to 800),
+                Triple(1920, 1080, 1024 to 600),
+                Triple(300, 500, 720 to 1280),
+                Triple(2856, 1280, 1920 to 3840),
+            )
+
+        boxes.forEach { (screenWidth, screenHeight, box) ->
+            val (boxWidth, boxHeight) = box
+            val result =
+                CaptureSizing.fitCaptureSizeToScreen(screenWidth, screenHeight, boxWidth, boxHeight)
+            if (result != null) {
+                val (width, height) = result
+                assertTrue("width even: $result", width % 2 == 0)
+                assertTrue("height even: $result", height % 2 == 0)
+                assertTrue("width <= box: $result vs $box", width <= boxWidth)
+                assertTrue("height <= box: $result vs $box", height <= boxHeight)
+                assertTrue(
+                    "width in bounds: $result",
+                    width in CaptureSizing.CAPTURE_WIDTH_MIN..CaptureSizing.CAPTURE_WIDTH_MAX,
+                )
+                assertTrue(
+                    "height in bounds: $result",
+                    height in CaptureSizing.CAPTURE_HEIGHT_MIN..CaptureSizing.CAPTURE_HEIGHT_MAX,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun fitCaptureSizeToScreen_defaultsToLegacyBoxWhenBoxOmitted() {
+        assertEquals(
+            CaptureSizing.deriveAutoCaptureSize(1080, 1920),
+            CaptureSizing.fitCaptureSizeToScreen(1080, 1920),
+        )
+    }
+
     private data class SizingCase(
         val name: String,
         val screenWidth: Int,
         val screenHeight: Int,
+        val expected: Pair<Int, Int>,
+    )
+
+    private data class BoxCase(
+        val name: String,
+        val screenWidth: Int,
+        val screenHeight: Int,
+        val boxWidth: Int,
+        val boxHeight: Int,
         val expected: Pair<Int, Int>,
     )
 }

--- a/docs/reverse-connection.md
+++ b/docs/reverse-connection.md
@@ -129,7 +129,7 @@ Streaming commands are only supported over reverse connection.
 ### Server → device
 
 - `stream/start`
-  - Params: `width`, `height`, `fps`, `sessionId`, `waitForOffer`, `iceServers`
+  - Params: `width`, `height`, `maxWidth`, `maxHeight`, `fps`, `sessionId`, `waitForOffer`, `iceServers`
 - `stream/stop`
 - `webrtc/answer` (for device-generated offers)
   - Params: `sdp`
@@ -139,6 +139,19 @@ Streaming commands are only supported over reverse connection.
   - Params: `candidate`, `sdpMid`, `sdpMLineIndex`, `sessionId`
 
 `iceServers` is an array of objects with `urls` and optional `username`/`credential`.
+
+`width`/`height` request an absolute capture size (legacy behavior, unchanged).
+`maxWidth`/`maxHeight` request a bounding box instead: the device aspect-fits its
+own screen into that box (no upscaling), like scrcpy's `--max-size`. They are an
+atomic pair — both must be present and positive, otherwise the pair is ignored.
+When present, `maxWidth`/`maxHeight` take precedence over `width`/`height`. If the
+fit can't be computed (display read failure or the fit falls outside the
+supported capture bounds), the cap is treated as absent and the device falls
+back to its default auto-sized capture — which may be larger than the
+requested box. `webrtc/connect` and `webrtc/rtcConfiguration` accept the same
+`width`/`height`/`maxWidth`/`maxHeight` params. Because the device may adjust the
+requested size, consumers must read the actual frame dimensions from the decoder
+rather than assuming the requested size was honored exactly.
 
 ### Device → server
 

--- a/docs/reverse-connection.md
+++ b/docs/reverse-connection.md
@@ -149,9 +149,13 @@ fit can't be computed (display read failure or the fit falls outside the
 supported capture bounds), the cap is treated as absent and the device falls
 back to its default auto-sized capture — which may be larger than the
 requested box. `webrtc/connect` and `webrtc/rtcConfiguration` accept the same
-`width`/`height`/`maxWidth`/`maxHeight` params. Because the device may adjust the
-requested size, consumers must read the actual frame dimensions from the decoder
-rather than assuming the requested size was honored exactly.
+`width`/`height`/`maxWidth`/`maxHeight` params. Size params (absolute and cap
+alike) govern the shared capture: they are honored when a stream starts or
+reuses the capture as the primary session, while secondary sessions always
+inherit the primary's capture size and ignore their own size params. Because
+the device may adjust the requested size, consumers must read the actual frame
+dimensions from the decoder rather than assuming the requested size was
+honored exactly.
 
 ### Device → server
 


### PR DESCRIPTION
## Problem

The stream API only understands **absolute** `width`/`height`. devices-api#608 works around this by aspect-fitting on the server and sending absolute dims — correct, but the wire semantics stay ad-hoc. Target model (per review discussion on devices-api#608) is scrcpy's: the client sends a **cap**, the device fits its own screen into it.

## Changes

New optional stream params `maxWidth`/`maxHeight` (both `stream/start` and `webrtc/connect`/`rtcConfiguration` — they share `selectCaptureSize`):

- **Bounding-box mode** (`ApiHandler`, `CaptureSizing`): when both are present and positive, the device aspect-fits its real screen into the box — `fitCaptureSizeToScreen` generalized to an arbitrary box, keeping #153's invariants: no upscaling, integer cross-product math, floor-to-even, wholesale per-axis bounds rejection (144–1920 / 256–3840), result never exceeds the box.
- **Atomic pair**: partial pair, zero, negative, or non-numeric → treated as absent, legacy behavior applies. When active, `maxWidth`/`maxHeight` take precedence over `width`/`height`.
- **Fail-soft**: display-read failure or rejected fit → cap treated as absent, fall back to auto-sizing (#153). Deliberate trade-off: a degenerate cap (below capture minima) must not fail stream start, so the fallback may exceed the requested box — documented in code and docs.
- **Permission-grant re-derivation** (`ScreenCaptureActivity`): cap mode re-derives from the live display with the same cap box at grant time, mirroring the existing `EXTRA_AUTO_CAPTURE_SIZE` path (rotation between request and grant handled identically).
- `docs/reverse-connection.md`: documents `width`/`height` (absolute, unchanged) vs `maxWidth`/`maxHeight` (cap), precedence, fallback; consumers must read actual frame size from the decoder.

## Compatibility

- `width`/`height` semantics untouched — no breaking change for existing callers.
- Old servers never send `maxWidth`/`maxHeight` → behavior identical to #153.
- devices-api will send both (aspect-matched absolute for deployed apps, cap for this version onward) during the transition; follow-up on devices-api#608.

## Tests

- `CaptureSizingTest`: arbitrary-box fits (cap smaller/larger than screen, landscape), per-axis min-bound accept/reject boundary pairs, invariant checks (even, ≤ box, in bounds), default-box equivalence. 10/10 green.
- `ApiHandlerTest`: table-driven cap-mode activation (atomicity, zero/negative/string inputs, precedence), intent-extra forwarding only in cap mode. 46/46 green.

## Verification status

**UNVERIFIED at runtime.** Unit tests only. After a release: start a stream with `maxWidth`/`maxHeight` on a real device → expect aspect-correct frame within the box and accurate corner taps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)