### PR TITLE
fix(a11y): include non-focusable PopupWindow roots

### DIFF
--- a/app/src/androidTest/java/com/mobilerun/portal/core/PopupWindowFixtureInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mobilerun/portal/core/PopupWindowFixtureInstrumentedTest.kt
@@ -1,0 +1,290 @@
+package com.mobilerun.portal.core
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.app.UiAutomation
+import android.os.SystemClock
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@Suppress("DEPRECATION")
+class PopupWindowFixtureInstrumentedTest {
+
+    @Test
+    fun nonFocusablePopup_isASeparateInteractiveApplicationWindow() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiAutomation = instrumentation.uiAutomation
+
+        withInteractiveWindowRetrieval(uiAutomation) {
+            ActivityScenario.launch(PopupWindowFixtureActivity::class.java).use { scenario ->
+                waitForSnapshot(uiAutomation, "fixture activity to become active") { snapshot ->
+                    snapshot.activeRoot.containsUnderlyingMarker
+                }
+
+                scenario.onActivity { it.showPopup(focusable = false) }
+
+                val shown = waitForSnapshot(
+                    uiAutomation,
+                    "non-focusable popup to appear as a separate interactive window",
+                ) { snapshot ->
+                    val popupWindows = snapshot.windows.filter { it.containsPopupMarker }
+                    snapshot.activeRoot.containsUnderlyingMarker &&
+                        !snapshot.activeRoot.containsPopupMarker &&
+                        popupWindows.size == 1 &&
+                        popupWindows.single().containsPopupActionMarker &&
+                        popupWindows.single().id != snapshot.activeRoot.windowId
+                }
+
+                val popupWindow = shown.windows.single { it.containsPopupMarker }
+                assertEquals(AccessibilityWindowInfo.TYPE_APPLICATION, popupWindow.type)
+                assertNotEquals(shown.activeRoot.windowId, popupWindow.id)
+                assertFalse(shown.activeRoot.containsPopupMarker)
+                assertTrue(performPopupAction(uiAutomation))
+
+                waitForSnapshot(uiAutomation, "popup action click to reach the activity") { snapshot ->
+                    snapshot.activeRoot.containsActionClickedMarker &&
+                        snapshot.windows.any { it.containsPopupMarker }
+                }
+
+                scenario.onActivity { it.dismissPopup() }
+
+                waitForSnapshot(uiAutomation, "non-focusable popup to be dismissed") { snapshot ->
+                    snapshot.activeRoot.containsUnderlyingMarker &&
+                        snapshot.windows.none {
+                            it.containsPopupMarker || it.containsPopupActionMarker
+                        }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun focusablePopup_becomesTheActiveApplicationWindow() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiAutomation = instrumentation.uiAutomation
+
+        withInteractiveWindowRetrieval(uiAutomation) {
+            ActivityScenario.launch(PopupWindowFixtureActivity::class.java).use { scenario ->
+                waitForSnapshot(uiAutomation, "fixture activity to become active") { snapshot ->
+                    snapshot.activeRoot.containsUnderlyingMarker
+                }
+
+                scenario.onActivity { it.showPopup(focusable = true) }
+
+                val shown = waitForSnapshot(
+                    uiAutomation,
+                    "focusable popup to become the active window",
+                ) { snapshot ->
+                    val popupWindows = snapshot.windows.filter { it.containsPopupMarker }
+                    snapshot.activeRoot.containsPopupMarker &&
+                        snapshot.activeRoot.containsPopupActionMarker &&
+                        popupWindows.size == 1 &&
+                        popupWindows.single().id == snapshot.activeRoot.windowId &&
+                        popupWindows.single().isActive &&
+                        popupWindows.single().isFocused
+                }
+
+                val popupWindow = shown.windows.single { it.containsPopupMarker }
+                assertEquals(AccessibilityWindowInfo.TYPE_APPLICATION, popupWindow.type)
+                assertEquals(shown.activeRoot.windowId, popupWindow.id)
+                assertFalse(shown.activeRoot.containsUnderlyingMarker)
+
+                scenario.onActivity { it.dismissPopup() }
+
+                waitForSnapshot(uiAutomation, "activity to become active after popup dismissal") {
+                    snapshot ->
+                    snapshot.activeRoot.containsUnderlyingMarker &&
+                        !snapshot.activeRoot.containsPopupMarker &&
+                        snapshot.windows.none { it.containsPopupMarker }
+                }
+            }
+        }
+    }
+
+    private fun withInteractiveWindowRetrieval(
+        uiAutomation: UiAutomation,
+        block: () -> Unit,
+    ) {
+        val serviceInfo = uiAutomation.serviceInfo
+        val originalFlags = serviceInfo.flags
+
+        try {
+            serviceInfo.flags = originalFlags or
+                AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+            uiAutomation.serviceInfo = serviceInfo
+            block()
+        } finally {
+            serviceInfo.flags = originalFlags
+            uiAutomation.serviceInfo = serviceInfo
+        }
+    }
+
+    private fun waitForSnapshot(
+        uiAutomation: UiAutomation,
+        description: String,
+        predicate: (UiSnapshot) -> Boolean,
+    ): UiSnapshot {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val deadline = SystemClock.uptimeMillis() + WINDOW_TIMEOUT_MS
+        var lastSnapshot: UiSnapshot
+
+        do {
+            instrumentation.waitForIdleSync()
+            lastSnapshot = takeSnapshot(uiAutomation)
+            if (predicate(lastSnapshot)) {
+                return lastSnapshot
+            }
+            SystemClock.sleep(WINDOW_POLL_INTERVAL_MS)
+        } while (SystemClock.uptimeMillis() < deadline)
+
+        throw AssertionError("Timed out waiting for $description; last snapshot=$lastSnapshot")
+    }
+
+    private fun takeSnapshot(uiAutomation: UiAutomation): UiSnapshot {
+        val activeRoot = uiAutomation.rootInActiveWindow
+        val activeRootSnapshot = try {
+            activeRoot?.toRootSnapshot() ?: RootSnapshot.EMPTY
+        } finally {
+            activeRoot?.recycle()
+        }
+
+        val windows = uiAutomation.windows.orEmpty()
+        val windowSnapshots = try {
+            windows.map { window -> window.toWindowSnapshot() }
+        } finally {
+            windows.forEach { it.recycle() }
+        }
+
+        return UiSnapshot(activeRootSnapshot, windowSnapshots)
+    }
+
+    private fun AccessibilityWindowInfo.toWindowSnapshot(): WindowSnapshot {
+        val windowRoot = root
+        val rootSnapshot = try {
+            windowRoot?.toRootSnapshot() ?: RootSnapshot.EMPTY
+        } finally {
+            windowRoot?.recycle()
+        }
+
+        return WindowSnapshot(
+            id = id,
+            type = type,
+            layer = layer,
+            isActive = isActive,
+            isFocused = isFocused,
+            containsUnderlyingMarker = rootSnapshot.containsUnderlyingMarker,
+            containsPopupMarker = rootSnapshot.containsPopupMarker,
+            containsPopupActionMarker = rootSnapshot.containsPopupActionMarker,
+        )
+    }
+
+    private fun AccessibilityNodeInfo.toRootSnapshot(): RootSnapshot = RootSnapshot(
+        windowId = windowId,
+        containsUnderlyingMarker = containsExactMarker(
+            PopupWindowFixtureActivity.UNDERLYING_MARKER,
+        ),
+        containsPopupMarker = containsExactMarker(PopupWindowFixtureActivity.POPUP_MARKER),
+        containsPopupActionMarker = containsExactMarker(
+            PopupWindowFixtureActivity.POPUP_ACTION_MARKER,
+        ),
+        containsActionClickedMarker = containsExactMarker(
+            PopupWindowFixtureActivity.ACTION_CLICKED_MARKER,
+        ),
+    )
+
+    private fun AccessibilityNodeInfo.containsExactMarker(marker: String): Boolean {
+        val candidates = findAccessibilityNodeInfosByText(marker)
+        return try {
+            candidates.any { candidate ->
+                candidate.text?.toString() == marker ||
+                    candidate.contentDescription?.toString() == marker
+            }
+        } finally {
+            candidates.forEach { it.recycle() }
+        }
+    }
+
+    private fun performPopupAction(uiAutomation: UiAutomation): Boolean {
+        val windows = uiAutomation.windows.orEmpty()
+        try {
+            windows.forEach { window ->
+                val windowRoot = window.root
+                try {
+                    if (windowRoot != null && performPopupAction(windowRoot)) {
+                        return true
+                    }
+                } finally {
+                    windowRoot?.recycle()
+                }
+            }
+        } finally {
+            windows.forEach { it.recycle() }
+        }
+        return false
+    }
+
+    private fun performPopupAction(root: AccessibilityNodeInfo): Boolean {
+        val candidates = root.findAccessibilityNodeInfosByText(
+            PopupWindowFixtureActivity.POPUP_ACTION_MARKER,
+        )
+        return try {
+            val action = candidates.firstOrNull { candidate ->
+                candidate.text?.toString() == PopupWindowFixtureActivity.POPUP_ACTION_MARKER ||
+                    candidate.contentDescription?.toString() ==
+                    PopupWindowFixtureActivity.POPUP_ACTION_MARKER
+            }
+            action?.performAction(AccessibilityNodeInfo.ACTION_CLICK) == true
+        } finally {
+            candidates.forEach { it.recycle() }
+        }
+    }
+
+    private data class UiSnapshot(
+        val activeRoot: RootSnapshot,
+        val windows: List<WindowSnapshot>,
+    )
+
+    private data class RootSnapshot(
+        val windowId: Int,
+        val containsUnderlyingMarker: Boolean,
+        val containsPopupMarker: Boolean,
+        val containsPopupActionMarker: Boolean,
+        val containsActionClickedMarker: Boolean,
+    ) {
+        companion object {
+            val EMPTY = RootSnapshot(
+                windowId = UNDEFINED_WINDOW_ID,
+                containsUnderlyingMarker = false,
+                containsPopupMarker = false,
+                containsPopupActionMarker = false,
+                containsActionClickedMarker = false,
+            )
+        }
+    }
+
+    private data class WindowSnapshot(
+        val id: Int,
+        val type: Int,
+        val layer: Int,
+        val isActive: Boolean,
+        val isFocused: Boolean,
+        val containsUnderlyingMarker: Boolean,
+        val containsPopupMarker: Boolean,
+        val containsPopupActionMarker: Boolean,
+    )
+
+    private companion object {
+        const val WINDOW_TIMEOUT_MS = 10_000L
+        const val WINDOW_POLL_INTERVAL_MS = 100L
+        const val UNDEFINED_WINDOW_ID = -1
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,6 +3,10 @@
 
     <application>
         <activity
+            android:name=".core.PopupWindowFixtureActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar" />
+        <activity
             android:name=".core.UnboundedRangeFixtureActivity"
             android:exported="false"
             android:theme="@android:style/Theme.Material.Light.NoActionBar" />

--- a/app/src/debug/java/com/mobilerun/portal/core/PopupWindowFixtureActivity.kt
+++ b/app/src/debug/java/com/mobilerun/portal/core/PopupWindowFixtureActivity.kt
@@ -1,0 +1,134 @@
+package com.mobilerun.portal.core
+
+import android.app.Activity
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.PopupWindow
+import android.widget.TextView
+
+/**
+ * Debug-only host for exercising accessibility behavior across [PopupWindow] roots.
+ */
+class PopupWindowFixtureActivity : Activity() {
+
+    private lateinit var actionClickedMarkerView: TextView
+    private var popupWindow: PopupWindow? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val content = FrameLayout(this).apply {
+            setBackgroundColor(Color.WHITE)
+            addView(
+                LinearLayout(context).apply {
+                    orientation = LinearLayout.VERTICAL
+                    gravity = Gravity.CENTER
+                    setPadding(dp(24), dp(24), dp(24), dp(24))
+
+                    addView(markerView(UNDERLYING_MARKER))
+                    actionClickedMarkerView = markerView(ACTION_CLICKED_MARKER).apply {
+                        visibility = View.GONE
+                    }
+                    addView(actionClickedMarkerView)
+                },
+                FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                ),
+            )
+        }
+
+        setContentView(
+            content,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+    }
+
+    /** Shows a touchable popup whose focus behavior is controlled by [focusable]. */
+    fun showPopup(focusable: Boolean) {
+        popupWindow?.dismiss()
+        actionClickedMarkerView.visibility = View.GONE
+
+        val popupContent = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+            setPadding(dp(24), dp(20), dp(24), dp(20))
+            background = GradientDrawable().apply {
+                shape = GradientDrawable.RECTANGLE
+                cornerRadius = dp(12).toFloat()
+                setColor(Color.WHITE)
+                setStroke(dp(1), Color.DKGRAY)
+            }
+
+            addView(markerView(POPUP_MARKER))
+            addView(
+                Button(context).apply {
+                    text = POPUP_ACTION_MARKER
+                    contentDescription = POPUP_ACTION_MARKER
+                    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+                    setOnClickListener {
+                        actionClickedMarkerView.visibility = View.VISIBLE
+                    }
+                },
+            )
+        }
+
+        lateinit var popup: PopupWindow
+        popup = PopupWindow(
+            popupContent,
+            dp(320),
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+            focusable,
+        ).apply {
+            isTouchable = true
+            isOutsideTouchable = true
+            setBackgroundDrawable(ColorDrawable(Color.WHITE))
+            elevation = dp(8).toFloat()
+            setOnDismissListener {
+                if (popupWindow === popup) {
+                    popupWindow = null
+                }
+            }
+        }
+
+        popupWindow = popup
+        popup.showAtLocation(window.decorView, Gravity.CENTER, 0, 0)
+    }
+
+    fun dismissPopup() {
+        popupWindow?.dismiss()
+    }
+
+    override fun onDestroy() {
+        popupWindow?.dismiss()
+        popupWindow = null
+        super.onDestroy()
+    }
+
+    private fun markerView(marker: String): TextView = TextView(this).apply {
+        text = marker
+        contentDescription = marker
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    companion object {
+        const val UNDERLYING_MARKER = "mobilerun-popup-underlying"
+        const val POPUP_MARKER = "mobilerun-popup-window"
+        const val POPUP_ACTION_MARKER = "mobilerun-popup-action"
+        const val ACTION_CLICKED_MARKER = "mobilerun-popup-action-clicked"
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
@@ -33,10 +33,16 @@ internal object AccessibilityRootResolver {
 
         try {
             val descriptors = windows.mapNotNull(::describeWindow)
-            val activeLayer = descriptors
-                .firstOrNull { activeWindowId != UNDEFINED_WINDOW_ID && it.id == activeWindowId }
-                ?.layer
-                ?: 0
+            val activeLayer = if (activeRoot != null) {
+                descriptors
+                    .singleOrNull {
+                        activeWindowId != UNDEFINED_WINDOW_ID && it.id == activeWindowId
+                    }
+                    ?.layer
+                    ?: return listOf(RootCandidate(activeRoot, activeWindowId, 0))
+            } else {
+                0
+            }
             val candidates = mutableListOf<RootCandidate>()
             val knownWindowIds = mutableSetOf<Int>()
 
@@ -51,7 +57,8 @@ internal object AccessibilityRootResolver {
                 .asSequence()
                 .filter { descriptor ->
                     if (activeRoot != null) {
-                        descriptor.type == AccessibilityWindowInfo.TYPE_APPLICATION
+                        descriptor.type == AccessibilityWindowInfo.TYPE_APPLICATION &&
+                            descriptor.layer > activeLayer
                     } else {
                         descriptor.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
                             descriptor.type == AccessibilityWindowInfo.TYPE_SYSTEM

--- a/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
@@ -87,9 +87,10 @@ internal object AccessibilityRootResolver {
                 }
 
                 val duplicateRootIndex = candidates.indexOfFirst { candidate ->
-                    (windowId == UNDEFINED_WINDOW_ID ||
-                        candidate.windowId == UNDEFINED_WINDOW_ID) &&
-                        candidate.root == root
+                    candidate.root === root ||
+                        ((windowId == UNDEFINED_WINDOW_ID ||
+                            candidate.windowId == UNDEFINED_WINDOW_ID) &&
+                            candidate.root == root)
                 }
                 if (duplicateRootIndex >= 0) {
                     val existing = candidates[duplicateRootIndex]

--- a/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/AccessibilityRootResolver.kt
@@ -1,0 +1,189 @@
+package com.mobilerun.portal.core
+
+import android.util.Log
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.mobilerun.portal.service.MobilerunAccessibilityService
+
+internal object AccessibilityRootResolver {
+    private const val TAG = "AccessibilityRootResolver"
+    private const val UNDEFINED_WINDOW_ID = -1
+
+    internal data class RootCandidate(
+        val root: AccessibilityNodeInfo,
+        val windowId: Int,
+        val layer: Int,
+    )
+
+    private data class WindowDescriptor(
+        val window: AccessibilityWindowInfo,
+        val id: Int,
+        val layer: Int,
+        val type: Int,
+    )
+
+    fun resolve(service: MobilerunAccessibilityService): List<RootCandidate> {
+        val activeRoot = readActiveRoot(service)
+        val activeWindowId = activeRoot?.let(::readWindowId) ?: UNDEFINED_WINDOW_ID
+        val windows = readWindows(service)
+
+        if (windows == null) {
+            return activeRoot?.let { listOf(RootCandidate(it, activeWindowId, 0)) }.orEmpty()
+        }
+
+        try {
+            val descriptors = windows.mapNotNull(::describeWindow)
+            val activeLayer = descriptors
+                .firstOrNull { activeWindowId != UNDEFINED_WINDOW_ID && it.id == activeWindowId }
+                ?.layer
+                ?: 0
+            val candidates = mutableListOf<RootCandidate>()
+            val knownWindowIds = mutableSetOf<Int>()
+
+            if (activeRoot != null) {
+                candidates += RootCandidate(activeRoot, activeWindowId, activeLayer)
+                if (activeWindowId != UNDEFINED_WINDOW_ID) {
+                    knownWindowIds += activeWindowId
+                }
+            }
+
+            val eligibleWindows = descriptors
+                .asSequence()
+                .filter { descriptor ->
+                    if (activeRoot != null) {
+                        descriptor.type == AccessibilityWindowInfo.TYPE_APPLICATION
+                    } else {
+                        descriptor.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
+                            descriptor.type == AccessibilityWindowInfo.TYPE_SYSTEM
+                    }
+                }
+                .sortedWith(
+                    compareBy<WindowDescriptor> {
+                        if (it.type == AccessibilityWindowInfo.TYPE_APPLICATION) 0 else 1
+                    }
+                        .thenByDescending { it.layer }
+                        .thenBy { it.id },
+                )
+
+            eligibleWindows.forEach { descriptor ->
+                if (descriptor.id != UNDEFINED_WINDOW_ID && descriptor.id in knownWindowIds) {
+                    return@forEach
+                }
+
+                val root = readWindowRoot(descriptor) ?: return@forEach
+                val windowId = descriptor.id.takeIf { it != UNDEFINED_WINDOW_ID }
+                    ?: readWindowId(root)
+
+                if (windowId != UNDEFINED_WINDOW_ID && windowId in knownWindowIds) {
+                    recycleDuplicateRoot(root, candidates)
+                    return@forEach
+                }
+
+                val duplicateRootIndex = candidates.indexOfFirst { candidate ->
+                    (windowId == UNDEFINED_WINDOW_ID ||
+                        candidate.windowId == UNDEFINED_WINDOW_ID) &&
+                        candidate.root == root
+                }
+                if (duplicateRootIndex >= 0) {
+                    val existing = candidates[duplicateRootIndex]
+                    if (existing.root === activeRoot && existing.windowId == UNDEFINED_WINDOW_ID) {
+                        candidates[duplicateRootIndex] = existing.copy(
+                            windowId = windowId,
+                            layer = descriptor.layer,
+                        )
+                        if (windowId != UNDEFINED_WINDOW_ID) {
+                            knownWindowIds += windowId
+                        }
+                    }
+                    recycleDuplicateRoot(root, candidates)
+                    return@forEach
+                }
+
+                candidates += RootCandidate(root, windowId, descriptor.layer)
+                if (windowId != UNDEFINED_WINDOW_ID) {
+                    knownWindowIds += windowId
+                }
+            }
+
+            return candidates
+        } finally {
+            windows.forEach(::recycleWindow)
+        }
+    }
+
+    private fun readActiveRoot(
+        service: MobilerunAccessibilityService,
+    ): AccessibilityNodeInfo? = try {
+        service.rootInActiveWindow
+    } catch (e: RuntimeException) {
+        logFailure("Unable to read active accessibility root", e)
+        null
+    }
+
+    private fun readWindows(
+        service: MobilerunAccessibilityService,
+    ): List<AccessibilityWindowInfo>? = try {
+        service.windows
+    } catch (e: RuntimeException) {
+        logFailure("Unable to read accessibility windows", e)
+        null
+    }
+
+    private fun describeWindow(window: AccessibilityWindowInfo): WindowDescriptor? = try {
+        WindowDescriptor(
+            window = window,
+            id = window.id,
+            layer = window.layer,
+            type = window.type,
+        )
+    } catch (e: RuntimeException) {
+        logFailure("Unable to inspect accessibility window", e)
+        null
+    }
+
+    private fun readWindowRoot(descriptor: WindowDescriptor): AccessibilityNodeInfo? = try {
+        descriptor.window.root
+    } catch (e: RuntimeException) {
+        logFailure(
+            "Unable to read accessibility window root id=${descriptor.id} layer=${descriptor.layer}",
+            e,
+        )
+        null
+    }
+
+    private fun readWindowId(root: AccessibilityNodeInfo): Int = try {
+        root.windowId
+    } catch (e: RuntimeException) {
+        logFailure("Unable to read accessibility root window ID", e)
+        UNDEFINED_WINDOW_ID
+    }
+
+    private fun recycleDuplicateRoot(
+        root: AccessibilityNodeInfo,
+        candidates: List<RootCandidate>,
+    ) {
+        if (candidates.none { it.root === root }) {
+            try {
+                root.recycle()
+            } catch (e: RuntimeException) {
+                logFailure("Unable to recycle duplicate accessibility root", e)
+            }
+        }
+    }
+
+    private fun recycleWindow(window: AccessibilityWindowInfo) {
+        try {
+            window.recycle()
+        } catch (e: RuntimeException) {
+            logFailure("Unable to recycle accessibility window", e)
+        }
+    }
+
+    private fun logFailure(message: String, error: RuntimeException) {
+        try {
+            Log.e(TAG, "$message: ${error.message}", error)
+        } catch (_: RuntimeException) {
+            // android.util.Log is unavailable in local JVM tests.
+        }
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
+++ b/app/src/main/java/com/mobilerun/portal/core/StateRepository.kt
@@ -3,10 +3,10 @@ package com.mobilerun.portal.core
 import android.graphics.Rect
 import android.util.Log
 import android.view.accessibility.AccessibilityNodeInfo
-import android.view.accessibility.AccessibilityWindowInfo
 import com.mobilerun.portal.service.MobilerunAccessibilityService
 import com.mobilerun.portal.model.ElementNode
 import com.mobilerun.portal.model.PhoneState
+import org.json.JSONArray
 import org.json.JSONObject
 
 class StateRepository(private val service: MobilerunAccessibilityService?) {
@@ -28,70 +28,64 @@ class StateRepository(private val service: MobilerunAccessibilityService?) {
      */
     fun hasActiveRoot(): Boolean {
         val svc = service ?: return false
-        val root = getActiveRoot(svc) ?: pickFallbackRoot(svc) ?: return false
-        root.recycle()
-        return true
+        val candidates = AccessibilityRootResolver.resolve(svc)
+        try {
+            return candidates.isNotEmpty()
+        } finally {
+            recycleRoots(candidates.map { it.root })
+        }
     }
 
     fun getFullTree(filter: Boolean): JSONObject? {
         val svc = service ?: return null
-        val root = getActiveRoot(svc) ?: pickFallbackRoot(svc) ?: return null
-        val bounds = if (filter) svc.getScreenBounds() else null
-        return AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root, bounds)
-    }
-
-    private fun getActiveRoot(svc: MobilerunAccessibilityService): AccessibilityNodeInfo? {
+        val candidates = AccessibilityRootResolver.resolve(svc)
+        var consumedCount = 0
         return try {
-            svc.rootInActiveWindow
-        } catch (e: RuntimeException) {
-            Log.e(TAG, "Unable to read active accessibility root: ${e.message}", e)
-            null
-        }
-    }
+            val bounds = if (filter) svc.getScreenBounds() else null
+            var primaryTree: JSONObject? = null
 
-    private fun pickFallbackRoot(svc: MobilerunAccessibilityService): AccessibilityNodeInfo? {
-        val windows = try {
-            svc.windows
-        } catch (e: RuntimeException) {
-            Log.e(TAG, "Unable to read accessibility windows: ${e.message}", e)
-            null
-        } ?: return null
+            for (candidate in candidates) {
+                // AccessibilityTreeBuilder owns and recycles every root passed to it,
+                // including when building fails. Mark the current candidate consumed
+                // before invoking it so cleanup only recycles untouched roots.
+                consumedCount++
+                val tree = AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(
+                    candidate.root,
+                    bounds,
+                ) ?: continue
 
-        return try {
-            windows.sortedWith(
-                compareBy<AccessibilityWindowInfo> { fallbackWindowTypePriority(it) }
-                    .thenByDescending { it.layer }
-            )
-                .asSequence()
-                .filter { isUserFacingWindow(it) }
-                .mapNotNull { window ->
-                    try {
-                        window.root
-                    } catch (e: RuntimeException) {
-                        Log.e(
-                            TAG,
-                            "Unable to read accessibility window root layer=${window.layer}: ${e.message}",
-                            e,
-                        )
-                        null
-                    }
+                val primary = primaryTree
+                if (primary == null) {
+                    primaryTree = tree
+                } else {
+                    appendAdditionalRoot(primary, tree)
                 }
-                .firstOrNull()
+            }
+
+            primaryTree
         } finally {
-            windows.forEach { it.recycle() }
+            recycleRoots(candidates.drop(consumedCount).map { it.root })
         }
     }
 
-    private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
-        return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
-                window.type == AccessibilityWindowInfo.TYPE_SYSTEM
+    private fun appendAdditionalRoot(primary: JSONObject, additionalRoot: JSONObject) {
+        val children = primary.optJSONArray("children") ?: JSONArray().also {
+            primary.put("children", it)
+        }
+        children.put(additionalRoot)
     }
 
-    private fun fallbackWindowTypePriority(window: AccessibilityWindowInfo): Int {
-        return when (window.type) {
-            AccessibilityWindowInfo.TYPE_APPLICATION -> 0
-            AccessibilityWindowInfo.TYPE_SYSTEM -> 1
-            else -> 2
+    private fun recycleRoots(roots: Iterable<AccessibilityNodeInfo>) {
+        roots.forEach { root ->
+            try {
+                root.recycle()
+            } catch (e: RuntimeException) {
+                try {
+                    Log.e(TAG, "Unable to recycle accessibility root: ${e.message}", e)
+                } catch (_: RuntimeException) {
+                    // android.util.Log is unavailable in local JVM tests.
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -23,6 +23,7 @@ import com.mobilerun.portal.model.ElementNode
 import com.mobilerun.portal.model.PhoneState
 import com.mobilerun.portal.api.ApiHandler
 import com.mobilerun.portal.core.AccessibilityTraversalGuard
+import com.mobilerun.portal.core.AccessibilityRootResolver
 import com.mobilerun.portal.core.StateRepository
 import com.mobilerun.portal.config.ConfigManager
 import com.mobilerun.portal.input.MobilerunKeyboardIME
@@ -103,6 +104,20 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
             bounds.right = safeWidth
             bounds.bottom = safeHeight
             return changed
+        }
+
+        internal fun recycleAccessibilityRoots(roots: Iterable<AccessibilityNodeInfo>) {
+            roots.forEach { root ->
+                try {
+                    root.recycle()
+                } catch (e: RuntimeException) {
+                    try {
+                        Log.e(TAG, "Unable to recycle accessibility root: ${e.message}", e)
+                    } catch (_: RuntimeException) {
+                        // android.util.Log is unavailable in local JVM tests.
+                    }
+                }
+            }
         }
 
         fun getInstance(): MobilerunAccessibilityService? = instance
@@ -663,7 +678,7 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         val indexCounter = IndexCounter(1)
         val screenBoundsSnapshot = refreshScreenBounds()
 
-        val rootCandidates = collectRootCandidates()
+        val rootCandidates = AccessibilityRootResolver.resolve(this)
         if (rootCandidates.isEmpty()) {
             synchronized(visibleElements) {
                 if (shouldReuseVisibleElementsSnapshot(
@@ -689,11 +704,18 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         }
 
         try {
-            for ((rootNode, layer) in rootCandidates) {
-                collectVisibleElements(rootNode, layer, null, elements, indexCounter, screenBoundsSnapshot)
+            for (candidate in rootCandidates) {
+                collectVisibleElements(
+                    candidate.root,
+                    candidate.layer,
+                    null,
+                    elements,
+                    indexCounter,
+                    screenBoundsSnapshot,
+                )
             }
         } finally {
-            rootCandidates.forEach { (node, _) -> node.recycle() }
+            recycleAccessibilityRoots(rootCandidates.map { candidate -> candidate.root })
         }
 
         synchronized(visibleElements) {
@@ -707,62 +729,6 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
         }
 
         return elements
-    }
-
-    private fun collectRootCandidates(): List<Pair<AccessibilityNodeInfo, Int>> {
-        val activeRoot = try {
-            rootInActiveWindow
-        } catch (e: RuntimeException) {
-            Log.e(TAG, "Unable to read active accessibility root: ${e.message}", e)
-            null
-        }
-        activeRoot?.let { return listOf(it to 0) }
-
-        val windows = try {
-            windows
-        } catch (e: RuntimeException) {
-            Log.e(TAG, "Unable to read accessibility windows: ${e.message}", e)
-            null
-        } ?: return emptyList()
-        val out = mutableListOf<Pair<AccessibilityNodeInfo, Int>>()
-        try {
-            windows.sortedWith(
-                compareBy<AccessibilityWindowInfo> { fallbackWindowTypePriority(it) }
-                    .thenByDescending { it.layer }
-            )
-                .filter { isUserFacingWindow(it) }
-                .forEach { window ->
-                    val root = try {
-                        window.root
-                    } catch (e: RuntimeException) {
-                        Log.e(
-                            TAG,
-                            "Unable to read accessibility window root layer=${window.layer}: ${e.message}",
-                            e,
-                        )
-                        null
-                    }
-                    if (root != null) {
-                        out.add(root to window.layer)
-                    }
-                }
-        } finally {
-            windows.forEach { it.recycle() }
-        }
-        return out
-    }
-
-    private fun isUserFacingWindow(window: AccessibilityWindowInfo): Boolean {
-        return window.type == AccessibilityWindowInfo.TYPE_APPLICATION ||
-                window.type == AccessibilityWindowInfo.TYPE_SYSTEM
-    }
-
-    private fun fallbackWindowTypePriority(window: AccessibilityWindowInfo): Int {
-        return when (window.type) {
-            AccessibilityWindowInfo.TYPE_APPLICATION -> 0
-            AccessibilityWindowInfo.TYPE_SYSTEM -> 1
-            else -> 2
-        }
     }
 
     private fun collectVisibleElements(

--- a/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
@@ -14,16 +14,20 @@ import org.junit.Test
 
 class AccessibilityRootResolverTest {
     @Test
-    fun activeRootStaysFirstAndApplicationExtrasUseDeterministicOrder() {
+    fun activeRootStaysFirstAndOnlyHigherApplicationExtrasUseDeterministicOrder() {
         val service = mockk<MobilerunAccessibilityService>()
         val activeRoot = root(windowId = 10)
         val popupHighId3 = root()
         val popupHighId2 = root()
         val popupLow = root()
+        val sameLayerRoot = root()
+        val obscuredActivityRoot = root()
         val activeWindow = window(id = 10, layer = 4, root = activeRoot)
         val highId3Window = window(id = 3, layer = 8, root = popupHighId3)
         val highId2Window = window(id = 2, layer = 8, root = popupHighId2)
         val lowWindow = window(id = 4, layer = 5, root = popupLow)
+        val sameLayerWindow = window(id = 6, layer = 4, root = sameLayerRoot)
+        val obscuredActivityWindow = window(id = 5, layer = 3, root = obscuredActivityRoot)
         val passiveSystemWindow = window(
             id = 99,
             layer = 20,
@@ -37,6 +41,8 @@ class AccessibilityRootResolverTest {
             passiveSystemWindow,
             highId3Window,
             activeWindow,
+            sameLayerWindow,
+            obscuredActivityWindow,
             highId2Window,
         )
 
@@ -49,15 +55,43 @@ class AccessibilityRootResolverTest {
         assertSame(popupHighId3, candidates[2].root)
         assertSame(popupLow, candidates[3].root)
         verify(exactly = 0) { activeWindow.root }
+        verify(exactly = 0) { sameLayerWindow.root }
+        verify(exactly = 0) { obscuredActivityWindow.root }
         verify(exactly = 0) { passiveSystemWindow.root }
         listOf(
             activeWindow,
             highId3Window,
             highId2Window,
             lowWindow,
+            sameLayerWindow,
+            obscuredActivityWindow,
             passiveSystemWindow,
         ).forEach { verify(exactly = 1) { it.recycle() } }
         candidates.forEach { candidate -> verify(exactly = 0) { candidate.root.recycle() } }
+    }
+
+    @Test
+    fun focusableActivePopupExcludesLowerLayerActivityRoot() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val popupRoot = root(windowId = 20)
+        val activityRoot = root(windowId = 10)
+        val popupWindow = window(id = 20, layer = 8, root = popupRoot)
+        val activityWindow = window(id = 10, layer = 1, root = activityRoot)
+
+        every { service.rootInActiveWindow } returns popupRoot
+        every { service.windows } returns listOf(activityWindow, popupWindow)
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(20), candidates.map { it.windowId })
+        assertEquals(listOf(8), candidates.map { it.layer })
+        assertSame(popupRoot, candidates.single().root)
+        verify(exactly = 0) { popupWindow.root }
+        verify(exactly = 0) { activityWindow.root }
+        verify(exactly = 1) { popupWindow.recycle() }
+        verify(exactly = 1) { activityWindow.recycle() }
+        verify(exactly = 0) { popupRoot.recycle() }
+        verify(exactly = 0) { activityRoot.recycle() }
     }
 
     @Test
@@ -92,38 +126,78 @@ class AccessibilityRootResolverTest {
     }
 
     @Test
-    fun duplicateWindowIdsAndUndefinedRootIdentityAreReturnedOnlyOnce() {
+    fun missingActiveWindowDescriptorReturnsOnlyActiveRoot() {
         val service = mockk<MobilerunAccessibilityService>()
-        val activeRoot = root(windowId = -1)
-        val otherUndefinedRoot = root(windowId = -1)
-        val validRoot = root()
-        val duplicateValidRoot = root()
-        val activeDuplicateWindow = window(id = -1, layer = 8, root = activeRoot)
-        val otherUndefinedWindow = window(id = -1, layer = 7, root = otherUndefinedRoot)
-        val validWindow = window(id = 5, layer = 6, root = validRoot)
-        val duplicateValidWindow = window(id = 5, layer = 5, root = duplicateValidRoot)
+        val activeRoot = root(windowId = 10)
+        val otherRoot = root(windowId = 20)
+        val otherWindow = window(id = 20, layer = 7, root = otherRoot)
 
         every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(otherWindow)
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(10), candidates.map { it.windowId })
+        assertEquals(listOf(0), candidates.map { it.layer })
+        assertSame(activeRoot, candidates.single().root)
+        verify(exactly = 0) { otherWindow.root }
+        verify(exactly = 1) { otherWindow.recycle() }
+        verify(exactly = 0) { activeRoot.recycle() }
+        verify(exactly = 0) { otherRoot.recycle() }
+    }
+
+    @Test
+    fun undefinedActiveWindowIdReturnsOnlyActiveRoot() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = -1)
+        val extraRoot = root(windowId = 20)
+        val extraWindow = window(id = 20, layer = 7, root = extraRoot)
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(extraWindow)
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(-1), candidates.map { it.windowId })
+        assertEquals(listOf(0), candidates.map { it.layer })
+        assertSame(activeRoot, candidates.single().root)
+        verify(exactly = 0) { extraWindow.root }
+        verify(exactly = 1) { extraWindow.recycle() }
+        verify(exactly = 0) { activeRoot.recycle() }
+        verify(exactly = 0) { extraRoot.recycle() }
+    }
+
+    @Test
+    fun noActiveRootDeduplicatesWindowIdsAndUndefinedRootIdentity() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val undefinedRoot = root(windowId = -1)
+        val validRoot = root()
+        val duplicateValidRoot = root()
+        val undefinedWindow = window(id = -1, layer = 7, root = undefinedRoot)
+        val duplicateUndefinedWindow = window(id = -1, layer = 6, root = undefinedRoot)
+        val validWindow = window(id = 5, layer = 5, root = validRoot)
+        val duplicateValidWindow = window(id = 5, layer = 4, root = duplicateValidRoot)
+
+        every { service.rootInActiveWindow } returns null
         every { service.windows } returns listOf(
             duplicateValidWindow,
             validWindow,
-            otherUndefinedWindow,
-            activeDuplicateWindow,
+            duplicateUndefinedWindow,
+            undefinedWindow,
         )
 
         val candidates = AccessibilityRootResolver.resolve(service)
 
-        assertEquals(listOf(-1, -1, 5), candidates.map { it.windowId })
-        assertEquals(listOf(8, 7, 6), candidates.map { it.layer })
-        assertSame(activeRoot, candidates[0].root)
-        assertSame(otherUndefinedRoot, candidates[1].root)
-        assertSame(validRoot, candidates[2].root)
+        assertEquals(listOf(-1, 5), candidates.map { it.windowId })
+        assertEquals(listOf(7, 5), candidates.map { it.layer })
+        assertSame(undefinedRoot, candidates[0].root)
+        assertSame(validRoot, candidates[1].root)
+        verify(exactly = 1) { duplicateUndefinedWindow.root }
         verify(exactly = 0) { duplicateValidWindow.root }
-        verify(exactly = 0) { activeRoot.recycle() }
         candidates.forEach { candidate -> verify(exactly = 0) { candidate.root.recycle() } }
         listOf(
-            activeDuplicateWindow,
-            otherUndefinedWindow,
+            undefinedWindow,
+            duplicateUndefinedWindow,
             validWindow,
             duplicateValidWindow,
         ).forEach { verify(exactly = 1) { it.recycle() } }

--- a/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
@@ -1,0 +1,194 @@
+package com.mobilerun.portal.core
+
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.mobilerun.portal.service.MobilerunAccessibilityService
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class AccessibilityRootResolverTest {
+    @Test
+    fun activeRootStaysFirstAndApplicationExtrasUseDeterministicOrder() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = 10)
+        val popupHighId3 = root()
+        val popupHighId2 = root()
+        val popupLow = root()
+        val activeWindow = window(id = 10, layer = 4, root = activeRoot)
+        val highId3Window = window(id = 3, layer = 8, root = popupHighId3)
+        val highId2Window = window(id = 2, layer = 8, root = popupHighId2)
+        val lowWindow = window(id = 4, layer = 5, root = popupLow)
+        val passiveSystemWindow = window(
+            id = 99,
+            layer = 20,
+            type = AccessibilityWindowInfo.TYPE_SYSTEM,
+            root = root(),
+        )
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(
+            lowWindow,
+            passiveSystemWindow,
+            highId3Window,
+            activeWindow,
+            highId2Window,
+        )
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(10, 2, 3, 4), candidates.map { it.windowId })
+        assertEquals(listOf(4, 8, 8, 5), candidates.map { it.layer })
+        assertSame(activeRoot, candidates[0].root)
+        assertSame(popupHighId2, candidates[1].root)
+        assertSame(popupHighId3, candidates[2].root)
+        assertSame(popupLow, candidates[3].root)
+        verify(exactly = 0) { activeWindow.root }
+        verify(exactly = 0) { passiveSystemWindow.root }
+        listOf(
+            activeWindow,
+            highId3Window,
+            highId2Window,
+            lowWindow,
+            passiveSystemWindow,
+        ).forEach { verify(exactly = 1) { it.recycle() } }
+        candidates.forEach { candidate -> verify(exactly = 0) { candidate.root.recycle() } }
+    }
+
+    @Test
+    fun missingActiveRootUsesApplicationWindowsBeforeSystemWindows() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val highAppRoot = root()
+        val lowAppRoot = root()
+        val systemRoot = root()
+        val emptyAppWindow = window(id = 9, layer = 20, root = null)
+        val highAppWindow = window(id = 7, layer = 10, root = highAppRoot)
+        val lowAppWindow = window(id = 5, layer = 1, root = lowAppRoot)
+        val systemWindow = window(
+            id = 1,
+            layer = 99,
+            type = AccessibilityWindowInfo.TYPE_SYSTEM,
+            root = systemRoot,
+        )
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(systemWindow, lowAppWindow, emptyAppWindow, highAppWindow)
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(7, 5, 1), candidates.map { it.windowId })
+        assertEquals(listOf(10, 1, 99), candidates.map { it.layer })
+        assertSame(highAppRoot, candidates[0].root)
+        assertSame(lowAppRoot, candidates[1].root)
+        assertSame(systemRoot, candidates[2].root)
+        listOf(emptyAppWindow, highAppWindow, lowAppWindow, systemWindow).forEach {
+            verify(exactly = 1) { it.recycle() }
+        }
+    }
+
+    @Test
+    fun duplicateWindowIdsAndUndefinedRootIdentityAreReturnedOnlyOnce() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = -1)
+        val otherUndefinedRoot = root(windowId = -1)
+        val validRoot = root()
+        val duplicateValidRoot = root()
+        val activeDuplicateWindow = window(id = -1, layer = 8, root = activeRoot)
+        val otherUndefinedWindow = window(id = -1, layer = 7, root = otherUndefinedRoot)
+        val validWindow = window(id = 5, layer = 6, root = validRoot)
+        val duplicateValidWindow = window(id = 5, layer = 5, root = duplicateValidRoot)
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(
+            duplicateValidWindow,
+            validWindow,
+            otherUndefinedWindow,
+            activeDuplicateWindow,
+        )
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(-1, -1, 5), candidates.map { it.windowId })
+        assertEquals(listOf(8, 7, 6), candidates.map { it.layer })
+        assertSame(activeRoot, candidates[0].root)
+        assertSame(otherUndefinedRoot, candidates[1].root)
+        assertSame(validRoot, candidates[2].root)
+        verify(exactly = 0) { duplicateValidWindow.root }
+        verify(exactly = 0) { activeRoot.recycle() }
+        candidates.forEach { candidate -> verify(exactly = 0) { candidate.root.recycle() } }
+        listOf(
+            activeDuplicateWindow,
+            otherUndefinedWindow,
+            validWindow,
+            duplicateValidWindow,
+        ).forEach { verify(exactly = 1) { it.recycle() } }
+    }
+
+    @Test
+    fun failingWindowIsSkippedWithoutPreventingLaterCandidatesOrRecycling() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val failingWindow = window(id = 8, layer = 9, root = null)
+        val malformedWindow = mockk<AccessibilityWindowInfo>()
+        val goodRoot = root()
+        val goodWindow = window(id = 7, layer = 1, root = goodRoot)
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(failingWindow, malformedWindow, goodWindow)
+        every { failingWindow.root } throws RuntimeException("root unavailable")
+        every { malformedWindow.id } throws RuntimeException("window unavailable")
+        every { malformedWindow.recycle() } just runs
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(7), candidates.map { it.windowId })
+        assertSame(goodRoot, candidates.single().root)
+        verify(exactly = 1) { failingWindow.recycle() }
+        verify(exactly = 1) { malformedWindow.recycle() }
+        verify(exactly = 1) { goodWindow.recycle() }
+    }
+
+    @Test
+    fun unavailableWindowListKeepsActiveRootWithDefaultLayer() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = 12)
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } throws RuntimeException("windows unavailable")
+
+        val candidate = AccessibilityRootResolver.resolve(service).single()
+
+        assertSame(activeRoot, candidate.root)
+        assertEquals(12, candidate.windowId)
+        assertEquals(0, candidate.layer)
+        verify(exactly = 0) { activeRoot.recycle() }
+    }
+
+    private fun root(windowId: Int? = null): AccessibilityNodeInfo {
+        return mockk<AccessibilityNodeInfo>().also { node ->
+            if (windowId != null) {
+                every { node.windowId } returns windowId
+            }
+            every { node.recycle() } just runs
+        }
+    }
+
+    private fun window(
+        id: Int,
+        layer: Int,
+        type: Int = AccessibilityWindowInfo.TYPE_APPLICATION,
+        root: AccessibilityNodeInfo?,
+    ): AccessibilityWindowInfo {
+        return mockk<AccessibilityWindowInfo>().also { window ->
+            every { window.id } returns id
+            every { window.layer } returns layer
+            every { window.type } returns type
+            every { window.root } returns root
+            every { window.recycle() } just runs
+        }
+    }
+}

--- a/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/AccessibilityRootResolverTest.kt
@@ -204,6 +204,31 @@ class AccessibilityRootResolverTest {
     }
 
     @Test
+    fun differentValidWindowIdsSharingOneRootHandleAreReturnedAndRecycledOnce() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val sharedRoot = root()
+        val higherWindow = window(id = 2, layer = 8, root = sharedRoot)
+        val lowerWindow = window(id = 3, layer = 7, root = sharedRoot)
+
+        every { service.rootInActiveWindow } returns null
+        every { service.windows } returns listOf(lowerWindow, higherWindow)
+
+        val candidates = AccessibilityRootResolver.resolve(service)
+
+        assertEquals(listOf(2), candidates.map { it.windowId })
+        assertSame(sharedRoot, candidates.single().root)
+        verify(exactly = 1) { higherWindow.root }
+        verify(exactly = 1) { lowerWindow.root }
+        verify(exactly = 0) { sharedRoot.recycle() }
+
+        candidates.single().root.recycle()
+
+        verify(exactly = 1) { sharedRoot.recycle() }
+        verify(exactly = 1) { higherWindow.recycle() }
+        verify(exactly = 1) { lowerWindow.recycle() }
+    }
+
+    @Test
     fun failingWindowIsSkippedWithoutPreventingLaterCandidatesOrRecycling() {
         val service = mockk<MobilerunAccessibilityService>()
         val failingWindow = window(id = 8, layer = 9, root = null)

--- a/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
@@ -11,12 +11,16 @@ import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.unmockkObject
 import io.mockk.verify
+import io.mockk.verifyOrder
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
-import org.json.JSONObject
 
 class StateRepositoryHeadlessTest {
     @Test
@@ -25,6 +29,7 @@ class StateRepositoryHeadlessTest {
         val phoneState = repository.getPhoneState()
 
         assertFalse(repository.hasAccessibilityService)
+        assertFalse(repository.hasActiveRoot())
         assertTrue(repository.getVisibleElements().isEmpty())
         assertNull(repository.getFullTree(filter = true))
         assertFalse(repository.setOverlayVisible(true))
@@ -35,102 +40,304 @@ class StateRepositoryHeadlessTest {
     }
 
     @Test
-    fun fullTreeFallbackSkipsUserFacingWindowsWithNullRoots() {
+    fun fullTreeAppendsPopupAfterPrimaryNativeChildren() {
         val service = mockk<MobilerunAccessibilityService>()
-        val emptyTopWindow = mockk<AccessibilityWindowInfo>()
-        val appWindow = mockk<AccessibilityWindowInfo>()
-        val root = mockk<AccessibilityNodeInfo>()
-        val expected = JSONObject().put("ok", true)
+        val activeRoot = root(windowId = 10)
+        val popupRoot = root(windowId = 20)
+        val activeWindow = window(
+            id = 10,
+            layer = 1,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = activeRoot,
+        )
+        val popupWindow = window(
+            id = 20,
+            layer = 5,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = popupRoot,
+        )
+        val nativeChild = tree("native-child")
+        val primary = tree("activity", childCount = 1, children = listOf(nativeChild))
+        val popup = tree("popup")
 
-        every { service.rootInActiveWindow } returns null
-        every { service.windows } returns listOf(emptyTopWindow, appWindow)
-        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
-        every { emptyTopWindow.layer } returns 2
-        every { emptyTopWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
-        every { emptyTopWindow.root } returns null
-        every { emptyTopWindow.recycle() } just runs
-        every { appWindow.layer } returns 1
-        every { appWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
-        every { appWindow.root } returns root
-        every { appWindow.recycle() } just runs
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(activeWindow, popupWindow)
 
         mockkObject(AccessibilityTreeBuilder)
         try {
             every {
-                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(root, any())
-            } returns expected
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, null)
+            } returns primary
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, null)
+            } returns popup
 
-            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+            val result = StateRepository(service).getFullTree(filter = false)
 
-            verify { emptyTopWindow.root }
-            verify { appWindow.root }
+            assertSame(primary, result)
+            assertEquals(1, result!!.getInt("childCount"))
+            val children = result.getJSONArray("children")
+            assertEquals(2, children.length())
+            assertSame(nativeChild, children.getJSONObject(0))
+            assertSame(popup, children.getJSONObject(1))
+            verifyOrder {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, null)
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, null)
+            }
+            verify(exactly = 0) { activeWindow.root }
+            verify { activeWindow.recycle() }
+            verify { popupWindow.recycle() }
         } finally {
             unmockkObject(AccessibilityTreeBuilder)
         }
     }
 
     @Test
-    fun fullTreeFallbackPrefersApplicationRootOverHigherLayerSystemRoot() {
+    fun fullTreePromotesFirstUnfilteredExtraAndAppendsLaterRoots() {
         val service = mockk<MobilerunAccessibilityService>()
-        val systemWindow = mockk<AccessibilityWindowInfo>()
-        val appWindow = mockk<AccessibilityWindowInfo>()
-        val systemRoot = mockk<AccessibilityNodeInfo>()
-        val appRoot = mockk<AccessibilityNodeInfo>()
-        val expected = JSONObject().put("app", true)
+        val activeRoot = root(windowId = 1)
+        val lowerRoot = root(windowId = 2)
+        val popupRoot = root(windowId = 3)
+        val activeWindow = window(
+            id = 1,
+            layer = 1,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = activeRoot,
+        )
+        val lowerWindow = window(
+            id = 2,
+            layer = 4,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = lowerRoot,
+        )
+        val popupWindow = window(
+            id = 3,
+            layer = 8,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = popupRoot,
+        )
+        val bounds = Rect(0, 0, 100, 100)
+        val popupNativeChild = tree("popup-native-child")
+        val popup = tree("popup", childCount = 1, children = listOf(popupNativeChild))
+        val lower = tree("lower-window")
 
-        every { service.rootInActiveWindow } returns null
-        every { service.windows } returns listOf(systemWindow, appWindow)
-        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
-        every { systemWindow.layer } returns 10
-        every { systemWindow.type } returns AccessibilityWindowInfo.TYPE_SYSTEM
-        every { systemWindow.root } returns systemRoot
-        every { systemWindow.recycle() } just runs
-        every { appWindow.layer } returns 1
-        every { appWindow.type } returns AccessibilityWindowInfo.TYPE_APPLICATION
-        every { appWindow.root } returns appRoot
-        every { appWindow.recycle() } just runs
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(lowerWindow, activeWindow, popupWindow)
+        every { service.getScreenBounds() } returns bounds
 
         mockkObject(AccessibilityTreeBuilder)
         try {
             every {
-                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(appRoot, any())
-            } returns expected
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, any())
+            } returns null
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, any())
+            } returns popup
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(lowerRoot, any())
+            } returns lower
 
-            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+            val result = StateRepository(service).getFullTree(filter = true)
 
-            verify { appWindow.root }
-            verify(exactly = 0) { systemWindow.root }
+            assertSame(popup, result)
+            assertEquals(1, result!!.getInt("childCount"))
+            val children = result.getJSONArray("children")
+            assertEquals(2, children.length())
+            assertSame(popupNativeChild, children.getJSONObject(0))
+            assertSame(lower, children.getJSONObject(1))
+            verifyOrder {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, any())
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, any())
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(lowerRoot, any())
+            }
         } finally {
             unmockkObject(AccessibilityTreeBuilder)
         }
     }
 
     @Test
-    fun fullTreeFallbackUsesSystemRootWhenNoApplicationRootExists() {
+    fun fullTreeFallbackSkipsNullRootsAndMergesApplicationBeforeSystem() {
         val service = mockk<MobilerunAccessibilityService>()
-        val systemWindow = mockk<AccessibilityWindowInfo>()
-        val systemRoot = mockk<AccessibilityNodeInfo>()
-        val expected = JSONObject().put("system", true)
+        val appRoot = root(windowId = 2)
+        val systemRoot = root(windowId = 3)
+        val emptyAppWindow = window(
+            id = 1,
+            layer = 9,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = null,
+        )
+        val appWindow = window(
+            id = 2,
+            layer = 2,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = appRoot,
+        )
+        val systemWindow = window(
+            id = 3,
+            layer = 10,
+            type = AccessibilityWindowInfo.TYPE_SYSTEM,
+            root = systemRoot,
+        )
+        val appNativeChild = tree("app-native-child")
+        val app = tree("app", childCount = 1, children = listOf(appNativeChild))
+        val system = tree("system")
 
         every { service.rootInActiveWindow } returns null
-        every { service.windows } returns listOf(systemWindow)
-        every { service.getScreenBounds() } returns Rect(0, 0, 100, 100)
-        every { systemWindow.layer } returns 1
-        every { systemWindow.type } returns AccessibilityWindowInfo.TYPE_SYSTEM
-        every { systemWindow.root } returns systemRoot
-        every { systemWindow.recycle() } just runs
+        every { service.windows } returns listOf(systemWindow, emptyAppWindow, appWindow)
 
         mockkObject(AccessibilityTreeBuilder)
         try {
             every {
-                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(systemRoot, any())
-            } returns expected
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(appRoot, null)
+            } returns app
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(systemRoot, null)
+            } returns system
 
-            assertSame(expected, StateRepository(service).getFullTree(filter = true))
+            val result = StateRepository(service).getFullTree(filter = false)
 
-            verify { systemWindow.root }
+            assertSame(app, result)
+            val children = result!!.getJSONArray("children")
+            assertEquals(2, children.length())
+            assertSame(appNativeChild, children.getJSONObject(0))
+            assertSame(system, children.getJSONObject(1))
+            verify { emptyAppWindow.root }
+            verifyOrder {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(appRoot, null)
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(systemRoot, null)
+            }
+            verify { emptyAppWindow.recycle() }
+            verify { appWindow.recycle() }
+            verify { systemWindow.recycle() }
         } finally {
             unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
+
+    @Test
+    fun fullTreeKeepsSingleRootObjectUnchanged() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = 7)
+        val activeWindow = window(
+            id = 7,
+            layer = 1,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = activeRoot,
+        )
+        val expected = JSONObject().put("unchanged", true)
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(activeWindow)
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, null)
+            } returns expected
+
+            val result = StateRepository(service).getFullTree(filter = false)
+
+            assertSame(expected, result)
+            assertFalse(result!!.has("children"))
+            verify(exactly = 0) { service.getScreenBounds() }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
+
+    @Test
+    fun hasActiveRootRecyclesEveryResolvedCandidate() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = 10)
+        val popupRoot = root(windowId = 20)
+        val activeWindow = window(
+            id = 10,
+            layer = 1,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = activeRoot,
+        )
+        val popupWindow = window(
+            id = 20,
+            layer = 5,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = popupRoot,
+        )
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(activeWindow, popupWindow)
+
+        assertTrue(StateRepository(service).hasActiveRoot())
+
+        verify(exactly = 1) { activeRoot.recycle() }
+        verify(exactly = 1) { popupRoot.recycle() }
+    }
+
+    @Test
+    fun fullTreeRecyclesOnlyUnprocessedRootsWhenBuilderThrows() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activeRoot = root(windowId = 1)
+        val popupRoot = root(windowId = 2)
+        val lowerRoot = root(windowId = 3)
+        val activeWindow = window(1, 1, AccessibilityWindowInfo.TYPE_APPLICATION, activeRoot)
+        val popupWindow = window(2, 5, AccessibilityWindowInfo.TYPE_APPLICATION, popupRoot)
+        val lowerWindow = window(3, 2, AccessibilityWindowInfo.TYPE_APPLICATION, lowerRoot)
+        val expectedFailure = IllegalStateException("unexpected builder failure")
+
+        every { service.rootInActiveWindow } returns activeRoot
+        every { service.windows } returns listOf(activeWindow, lowerWindow, popupWindow)
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activeRoot, null)
+            } throws expectedFailure
+
+            try {
+                StateRepository(service).getFullTree(filter = false)
+                fail("Expected the builder failure to propagate")
+            } catch (actual: IllegalStateException) {
+                assertSame(expectedFailure, actual)
+            }
+
+            verify(exactly = 0) { activeRoot.recycle() }
+            verify(exactly = 1) { popupRoot.recycle() }
+            verify(exactly = 1) { lowerRoot.recycle() }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
+
+    private fun root(windowId: Int): AccessibilityNodeInfo {
+        return mockk<AccessibilityNodeInfo>().also { root ->
+            every { root.windowId } returns windowId
+            every { root.recycle() } just runs
+        }
+    }
+
+    private fun window(
+        id: Int,
+        layer: Int,
+        type: Int,
+        root: AccessibilityNodeInfo?,
+    ): AccessibilityWindowInfo {
+        return mockk<AccessibilityWindowInfo>().also { window ->
+            every { window.id } returns id
+            every { window.layer } returns layer
+            every { window.type } returns type
+            every { window.root } returns root
+            every { window.recycle() } just runs
+        }
+    }
+
+    private fun tree(
+        name: String,
+        childCount: Int = 0,
+        children: List<JSONObject> = emptyList(),
+    ): JSONObject {
+        return JSONObject().apply {
+            put("name", name)
+            put("childCount", childCount)
+            put("children", JSONArray().apply { children.forEach(::put) })
         }
     }
 }

--- a/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/core/StateRepositoryHeadlessTest.kt
@@ -93,6 +93,50 @@ class StateRepositoryHeadlessTest {
     }
 
     @Test
+    fun fullTreeWithFocusableActivePopupExcludesLowerLayerActivityRoot() {
+        val service = mockk<MobilerunAccessibilityService>()
+        val activityRoot = root(windowId = 10)
+        val popupRoot = root(windowId = 20)
+        val activityWindow = window(
+            id = 10,
+            layer = 1,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = activityRoot,
+        )
+        val popupWindow = window(
+            id = 20,
+            layer = 5,
+            type = AccessibilityWindowInfo.TYPE_APPLICATION,
+            root = popupRoot,
+        )
+        val popup = tree("focusable-popup")
+
+        every { service.rootInActiveWindow } returns popupRoot
+        every { service.windows } returns listOf(activityWindow, popupWindow)
+
+        mockkObject(AccessibilityTreeBuilder)
+        try {
+            every {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, null)
+            } returns popup
+
+            val result = StateRepository(service).getFullTree(filter = false)
+
+            assertSame(popup, result)
+            verify(exactly = 1) {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(popupRoot, null)
+            }
+            verify(exactly = 0) {
+                AccessibilityTreeBuilder.buildFullAccessibilityTreeJson(activityRoot, any())
+            }
+            verify(exactly = 0) { activityWindow.root }
+            verify(exactly = 0) { activityRoot.recycle() }
+        } finally {
+            unmockkObject(AccessibilityTreeBuilder)
+        }
+    }
+
+    @Test
     fun fullTreePromotesFirstUnfilteredExtraAndAppendsLaterRoots() {
         val service = mockk<MobilerunAccessibilityService>()
         val activeRoot = root(windowId = 1)

--- a/app/src/test/java/com/mobilerun/portal/service/MobilerunAccessibilityServiceTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/MobilerunAccessibilityServiceTest.kt
@@ -1,12 +1,31 @@
 package com.mobilerun.portal.service
 
 import android.graphics.Rect
+import android.view.accessibility.AccessibilityNodeInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MobilerunAccessibilityServiceTest {
+
+    @Test
+    fun recycleAccessibilityRoots_continuesAfterFailure() {
+        val failingRoot = mockk<AccessibilityNodeInfo>()
+        val laterRoot = mockk<AccessibilityNodeInfo>()
+        every { failingRoot.recycle() } throws RuntimeException("stale root")
+        every { laterRoot.recycle() } returns Unit
+
+        MobilerunAccessibilityService.recycleAccessibilityRoots(
+            listOf(failingRoot, laterRoot),
+        )
+
+        verify(exactly = 1) { failingRoot.recycle() }
+        verify(exactly = 1) { laterRoot.recycle() }
+    }
 
     @Test
     fun updateScreenBounds_overwritesStalePortraitBoundsAfterLandscapeRotation() {


### PR DESCRIPTION
## Summary

- collect non-active interactive application-window roots alongside `rootInActiveWindow`
- merge additional roots into compact and full state without changing public response shapes or existing active-tree indices
- add permanent non-focusable/focusable `PopupWindow` regression coverage

## Root cause

Portal returned immediately whenever `rootInActiveWindow` was non-null, so it never queried `AccessibilityService.windows`. A touchable `focusable=false` `PopupWindow` remains a separate inactive `TYPE_APPLICATION` window, making its nodes visible to `getWindows()` but absent from Portal.

## Compatibility

- the active root remains first; extra application roots are sorted by descending layer and ascending window ID
- compact indices use one global counter and append popup indices
- full endpoints remain a single `JSONObject`; additional roots append after the primary root's native children and retain their real `windowId`
- passive system, IME, and accessibility-overlay windows are excluded while an active root exists
- root and window handles are recycled with per-handle failure isolation

## Android 16 validation

Tested on `Medium_Phone_API_36.1`, Android 16 / API 36.

- all 7 instrumentation tests passed
- `/a11y_tree`, `/state`, `/a11y_tree_full?filter=false`, and `/state_full?filter=false` returned both the underlying activity and non-focusable popup markers
- compact output had 12/12 unique indices; activity index 2 remained stable, with popup indices 10 and 12 appended
- full output retained the activity root and appended the distinct popup-window root
- tapping the popup action using the returned tree succeeded; focusable-popup and dismissal cases also passed

## Checks

- `./gradlew lintDebug assembleDebug --no-daemon`
- focused resolver, repository, service, tree, and API unit tests
- `ANDROID_SERIAL=emulator-5554 ./gradlew connectedDebugAndroidTest --no-daemon -PversionCode=515`
- full `testDebugUnitTest`: 525 tests, with only the documented pre-existing `SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates` failure; no new failures

Fixes #155