### PR TITLE
refactor(triggers): compiler-enforced enum mappings + predicate renames

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/triggers/TriggerApi.kt
+++ b/app/src/main/java/com/mobilerun/portal/triggers/TriggerApi.kt
@@ -176,7 +176,7 @@ class TriggerApi(
 
         var ruleToSave = validRule
         if (ruleToSave.enabled &&
-            TriggerEditorSupport.isNotificationSource(ruleToSave.source) &&
+            TriggerEditorSupport.requiresNotificationAccess(ruleToSave.source) &&
             !environmentStatusProvider.get(appContext).notificationAccessEnabled
         ) {
             ruleToSave = ruleToSave.copy(enabled = false)
@@ -209,7 +209,7 @@ class TriggerApi(
             "Trigger rule not found: $ruleId",
         )
         if (enabled &&
-            TriggerEditorSupport.isNotificationSource(existingRule.source) &&
+            TriggerEditorSupport.requiresNotificationAccess(existingRule.source) &&
             !environmentStatusProvider.get(appContext).notificationAccessEnabled
         ) {
             return TriggerApiResult.Error(
@@ -230,7 +230,7 @@ class TriggerApi(
         val rule = operations.getRule(ruleId) ?: return TriggerApiResult.Error(
             "Trigger rule not found: $ruleId",
         )
-        if (TriggerEditorSupport.isNotificationSource(rule.source) &&
+        if (TriggerEditorSupport.requiresNotificationAccess(rule.source) &&
             !environmentStatusProvider.get(appContext).notificationAccessEnabled
         ) {
             return TriggerApiResult.Error(

--- a/app/src/main/java/com/mobilerun/portal/triggers/TriggerEditorSupport.kt
+++ b/app/src/main/java/com/mobilerun/portal/triggers/TriggerEditorSupport.kt
@@ -76,7 +76,13 @@ object TriggerEditorSupport {
                 showCooldown = false,
             )
 
-            else -> Visibility()
+            // Sources that use the editor defaults on purpose.
+            TriggerSource.BATTERY_LOW,
+            TriggerSource.BATTERY_OKAY,
+            TriggerSource.POWER_CONNECTED,
+            TriggerSource.POWER_DISCONNECTED,
+            TriggerSource.USER_PRESENT,
+            -> Visibility()
         }
     }
 
@@ -143,7 +149,12 @@ object TriggerEditorSupport {
         )
     }
 
-    fun isNotificationSource(source: TriggerSource): Boolean {
+    /**
+     * True for sources that need the notification-listener permission.
+     * Distinct from [TriggerRuntime.shouldDebounce]: removed notifications
+     * need access too, but are never debounced.
+     */
+    fun requiresNotificationAccess(source: TriggerSource): Boolean {
         return source == TriggerSource.NOTIFICATION_POSTED ||
             source == TriggerSource.NOTIFICATION_REMOVED
     }

--- a/app/src/main/java/com/mobilerun/portal/triggers/TriggerRuntime.kt
+++ b/app/src/main/java/com/mobilerun/portal/triggers/TriggerRuntime.kt
@@ -159,23 +159,36 @@ object TriggerRuntime {
         evaluateRule(rule, buildTestSignal(rule), isTestRun = true)
     }
 
+    /**
+     * Exhaustive on purpose: a new [EventType] must get an explicit decision
+     * here — otherwise the API catalogue (and, via its paired [TriggerSource],
+     * the UI picker) would advertise a trigger that never fires.
+     */
+    internal fun triggerSourceFor(type: EventType): TriggerSource? = when (type) {
+        EventType.NOTIFICATION_POSTED -> TriggerSource.NOTIFICATION_POSTED
+        EventType.NOTIFICATION_REMOVED -> TriggerSource.NOTIFICATION_REMOVED
+        EventType.APP_ENTERED -> TriggerSource.APP_ENTERED
+        EventType.APP_EXITED -> TriggerSource.APP_EXITED
+        EventType.BATTERY_LOW -> TriggerSource.BATTERY_LOW
+        EventType.BATTERY_OKAY -> TriggerSource.BATTERY_OKAY
+        EventType.BATTERY_LEVEL_CHANGED -> TriggerSource.BATTERY_LEVEL_CHANGED
+        EventType.POWER_CONNECTED -> TriggerSource.POWER_CONNECTED
+        EventType.POWER_DISCONNECTED -> TriggerSource.POWER_DISCONNECTED
+        EventType.USER_PRESENT -> TriggerSource.USER_PRESENT
+        EventType.NETWORK_CONNECTED -> TriggerSource.NETWORK_CONNECTED
+        EventType.NETWORK_TYPE_CHANGED -> TriggerSource.NETWORK_TYPE_CHANGED
+        EventType.SMS_RECEIVED -> TriggerSource.SMS_RECEIVED
+        // Protocol/legacy members that never fire triggers.
+        EventType.NOTIFICATION,
+        EventType.PING,
+        EventType.PONG,
+        EventType.UNKNOWN,
+        -> null
+    }
+
     private fun handlePortalEvent(event: PortalEvent) {
-        val signal = when (event.type) {
-            EventType.NOTIFICATION_POSTED -> portalEventToSignal(TriggerSource.NOTIFICATION_POSTED, event)
-            EventType.NOTIFICATION_REMOVED -> portalEventToSignal(TriggerSource.NOTIFICATION_REMOVED, event)
-            EventType.APP_ENTERED -> portalEventToSignal(TriggerSource.APP_ENTERED, event)
-            EventType.APP_EXITED -> portalEventToSignal(TriggerSource.APP_EXITED, event)
-            EventType.BATTERY_LOW -> portalEventToSignal(TriggerSource.BATTERY_LOW, event)
-            EventType.BATTERY_OKAY -> portalEventToSignal(TriggerSource.BATTERY_OKAY, event)
-            EventType.BATTERY_LEVEL_CHANGED -> portalEventToSignal(TriggerSource.BATTERY_LEVEL_CHANGED, event)
-            EventType.POWER_CONNECTED -> portalEventToSignal(TriggerSource.POWER_CONNECTED, event)
-            EventType.POWER_DISCONNECTED -> portalEventToSignal(TriggerSource.POWER_DISCONNECTED, event)
-            EventType.USER_PRESENT -> portalEventToSignal(TriggerSource.USER_PRESENT, event)
-            EventType.NETWORK_CONNECTED -> portalEventToSignal(TriggerSource.NETWORK_CONNECTED, event)
-            EventType.NETWORK_TYPE_CHANGED -> portalEventToSignal(TriggerSource.NETWORK_TYPE_CHANGED, event)
-            EventType.SMS_RECEIVED -> portalEventToSignal(TriggerSource.SMS_RECEIVED, event)
-            else -> null
-        } ?: return
+        val source = triggerSourceFor(event.type) ?: return
+        val signal = portalEventToSignal(source, event) ?: return
 
         val nowMs = System.currentTimeMillis()
         repository.listRules()
@@ -185,7 +198,7 @@ object TriggerRuntime {
             .filterNot { isCoolingDown(it, nowMs) }
             .filter { TriggerMatcher.matches(it, signal) }
             .forEach { rule ->
-                if (isNotificationSource(signal.source)) {
+                if (shouldDebounce(signal.source)) {
                     logRun(
                         rule = rule,
                         disposition = TriggerRunDisposition.DEBOUNCED,
@@ -199,7 +212,13 @@ object TriggerRuntime {
             }
     }
 
-    private fun isNotificationSource(source: TriggerSource): Boolean =
+    /**
+     * Only posted notifications are debounced: the buffer batches message
+     * title/text per sender, which removed notifications don't carry — those
+     * evaluate immediately. Not the same predicate as
+     * [TriggerEditorSupport.requiresNotificationAccess].
+     */
+    internal fun shouldDebounce(source: TriggerSource): Boolean =
         source == TriggerSource.NOTIFICATION_POSTED
 
     private fun evaluateRule(rule: TriggerRule, signal: TriggerSignal, isTestRun: Boolean) {

--- a/app/src/main/java/com/mobilerun/portal/ui/triggers/TriggerRuleEditorActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/triggers/TriggerRuleEditorActivity.kt
@@ -779,7 +779,7 @@ class TriggerRuleEditorActivity : AppCompatActivity() {
         var rule = buildRuleOrShowErrors() ?: return null
 
         val needsNotificationAccess = rule.enabled &&
-            TriggerEditorSupport.isNotificationSource(rule.source) &&
+            TriggerEditorSupport.requiresNotificationAccess(rule.source) &&
             !TriggerEditorSupport.isNotificationAccessEnabled(this)
 
         if (needsNotificationAccess) {
@@ -825,7 +825,7 @@ class TriggerRuleEditorActivity : AppCompatActivity() {
 
     private fun testRule() {
         val savedRule = saveRule(finishAfterSave = false, showToast = false) ?: return
-        if (TriggerEditorSupport.isNotificationSource(savedRule.source) &&
+        if (TriggerEditorSupport.requiresNotificationAccess(savedRule.source) &&
             !TriggerEditorSupport.isNotificationAccessEnabled(this)
         ) {
             Toast.makeText(this, "Cannot test: notification listener access is not granted", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/mobilerun/portal/ui/triggers/TriggerRulesActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/triggers/TriggerRulesActivity.kt
@@ -141,7 +141,7 @@ class TriggerRulesActivity : AppCompatActivity() {
         ruleAdapter = RuleAdapter(
             onToggle = { rule, enabled ->
                 if (enabled &&
-                    TriggerEditorSupport.isNotificationSource(rule.source) &&
+                    TriggerEditorSupport.requiresNotificationAccess(rule.source) &&
                     !TriggerEditorSupport.isNotificationAccessEnabled(this)
                 ) {
                     showNotificationAccessWarning(rule.id)
@@ -275,7 +275,7 @@ class TriggerRulesActivity : AppCompatActivity() {
         if (isNotificationAccessEnabled()) return
         var changed = false
         for (rule in TriggerRuntime.listRules()) {
-            if (rule.enabled && TriggerEditorSupport.isNotificationSource(rule.source)) {
+            if (rule.enabled && TriggerEditorSupport.requiresNotificationAccess(rule.source)) {
                 TriggerRuntime.setRuleEnabled(rule.id, false)
                 changed = true
             }

--- a/app/src/test/java/com/mobilerun/portal/triggers/TriggerCoreTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/triggers/TriggerCoreTest.kt
@@ -1,9 +1,11 @@
 package com.mobilerun.portal.triggers
 
+import com.mobilerun.portal.events.model.EventType
 import com.mobilerun.portal.taskprompt.PortalTaskSettings
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.json.JSONObject
@@ -248,6 +250,155 @@ class TriggerCoreTest {
         assertEquals(expected.keys, TriggerSource.entries.toSet())
         expected.forEach { (source, description) ->
             assertEquals(description, TriggerUiSupport.sourceDescription(source))
+        }
+    }
+
+    @Test
+    fun `every trigger source has an intended visibility and cooldown decision`() {
+        val defaults = TriggerEditorSupport.Visibility()
+        val expected = mapOf(
+            TriggerSource.TIME_DELAY to TriggerEditorSupport.Visibility(
+                showDelay = true,
+                showCooldown = false,
+                showRunLimit = false,
+            ),
+            TriggerSource.TIME_ABSOLUTE to TriggerEditorSupport.Visibility(
+                showAbsoluteTime = true,
+                showCooldown = false,
+                showRunLimit = false,
+            ),
+            TriggerSource.TIME_DAILY to TriggerEditorSupport.Visibility(
+                showRecurringTime = true,
+                showCooldown = false,
+            ),
+            TriggerSource.TIME_WEEKLY to TriggerEditorSupport.Visibility(
+                showRecurringTime = true,
+                showCooldown = false,
+            ),
+            TriggerSource.NOTIFICATION_POSTED to TriggerEditorSupport.Visibility(
+                showMatchMode = true,
+                showPackageName = true,
+                showTitleFilter = true,
+                showTextFilter = true,
+            ),
+            TriggerSource.NOTIFICATION_REMOVED to TriggerEditorSupport.Visibility(
+                showMatchMode = true,
+                showPackageName = true,
+                showTitleFilter = true,
+                showTextFilter = true,
+            ),
+            TriggerSource.APP_ENTERED to TriggerEditorSupport.Visibility(
+                showMatchMode = true,
+                showPackageName = true,
+            ),
+            TriggerSource.APP_EXITED to TriggerEditorSupport.Visibility(
+                showMatchMode = true,
+                showPackageName = true,
+            ),
+            TriggerSource.BATTERY_LEVEL_CHANGED to TriggerEditorSupport.Visibility(
+                showThreshold = true,
+            ),
+            TriggerSource.NETWORK_CONNECTED to TriggerEditorSupport.Visibility(
+                showNetworkType = true,
+            ),
+            TriggerSource.NETWORK_TYPE_CHANGED to TriggerEditorSupport.Visibility(
+                showNetworkType = true,
+            ),
+            TriggerSource.SMS_RECEIVED to TriggerEditorSupport.Visibility(
+                showMatchMode = true,
+                showPhoneNumber = true,
+                showMessageFilter = true,
+            ),
+            // Intended-defaults allow-list: these sources deliberately use
+            // the plain editor defaults.
+            TriggerSource.BATTERY_LOW to defaults,
+            TriggerSource.BATTERY_OKAY to defaults,
+            TriggerSource.POWER_CONNECTED to defaults,
+            TriggerSource.POWER_DISCONNECTED to defaults,
+            TriggerSource.USER_PRESENT to defaults,
+        )
+
+        assertEquals(expected.keys, TriggerSource.entries.toSet())
+        expected.forEach { (source, visibility) ->
+            assertEquals(source.name, visibility, TriggerEditorSupport.visibilityFor(source))
+            val capabilities = TriggerEditorSupport.capabilitiesFor(source)
+            assertEquals(source.name, visibility.showCooldown, capabilities.supportsCooldown)
+            assertEquals(source.name, visibility.showRunLimit, capabilities.supportsRunLimit)
+            assertEquals(
+                source.name,
+                if (visibility.showCooldown) 60L else 0L,
+                TriggerEditorSupport.defaultCooldownSecondsFor(source).toLong(),
+            )
+        }
+    }
+
+    @Test
+    fun `portal event mapping decides every event type`() {
+        val expected = mapOf(
+            EventType.NOTIFICATION_POSTED to TriggerSource.NOTIFICATION_POSTED,
+            EventType.NOTIFICATION_REMOVED to TriggerSource.NOTIFICATION_REMOVED,
+            EventType.APP_ENTERED to TriggerSource.APP_ENTERED,
+            EventType.APP_EXITED to TriggerSource.APP_EXITED,
+            EventType.BATTERY_LOW to TriggerSource.BATTERY_LOW,
+            EventType.BATTERY_OKAY to TriggerSource.BATTERY_OKAY,
+            EventType.BATTERY_LEVEL_CHANGED to TriggerSource.BATTERY_LEVEL_CHANGED,
+            EventType.POWER_CONNECTED to TriggerSource.POWER_CONNECTED,
+            EventType.POWER_DISCONNECTED to TriggerSource.POWER_DISCONNECTED,
+            EventType.USER_PRESENT to TriggerSource.USER_PRESENT,
+            EventType.NETWORK_CONNECTED to TriggerSource.NETWORK_CONNECTED,
+            EventType.NETWORK_TYPE_CHANGED to TriggerSource.NETWORK_TYPE_CHANGED,
+            EventType.SMS_RECEIVED to TriggerSource.SMS_RECEIVED,
+        )
+        val intentionallyUnmapped = setOf(
+            EventType.NOTIFICATION,
+            EventType.PING,
+            EventType.PONG,
+            EventType.UNKNOWN,
+        )
+
+        assertEquals(expected.keys, EventType.entries.toSet() - intentionallyUnmapped)
+        expected.forEach { (type, source) ->
+            assertEquals(type.name, source, TriggerRuntime.triggerSourceFor(type))
+        }
+        intentionallyUnmapped.forEach { type ->
+            assertNull(type.name, TriggerRuntime.triggerSourceFor(type))
+        }
+    }
+
+    @Test
+    fun `every trigger source has a notification access and debounce decision`() {
+        // Pair(requiresNotificationAccess, shouldDebounce) per source.
+        val expected = mapOf(
+            TriggerSource.TIME_DELAY to Pair(false, false),
+            TriggerSource.TIME_ABSOLUTE to Pair(false, false),
+            TriggerSource.TIME_DAILY to Pair(false, false),
+            TriggerSource.TIME_WEEKLY to Pair(false, false),
+            TriggerSource.NOTIFICATION_POSTED to Pair(true, true),
+            // Removed notifications need listener access but carry no
+            // message text, so they are never debounced.
+            TriggerSource.NOTIFICATION_REMOVED to Pair(true, false),
+            TriggerSource.APP_ENTERED to Pair(false, false),
+            TriggerSource.APP_EXITED to Pair(false, false),
+            TriggerSource.BATTERY_LOW to Pair(false, false),
+            TriggerSource.BATTERY_OKAY to Pair(false, false),
+            TriggerSource.BATTERY_LEVEL_CHANGED to Pair(false, false),
+            TriggerSource.POWER_CONNECTED to Pair(false, false),
+            TriggerSource.POWER_DISCONNECTED to Pair(false, false),
+            TriggerSource.USER_PRESENT to Pair(false, false),
+            TriggerSource.NETWORK_CONNECTED to Pair(false, false),
+            TriggerSource.NETWORK_TYPE_CHANGED to Pair(false, false),
+            TriggerSource.SMS_RECEIVED to Pair(false, false),
+        )
+
+        assertEquals(expected.keys, TriggerSource.entries.toSet())
+        expected.forEach { (source, decision) ->
+            val (needsAccess, debounced) = decision
+            assertEquals(
+                source.name,
+                needsAccess,
+                TriggerEditorSupport.requiresNotificationAccess(source),
+            )
+            assertEquals(source.name, debounced, TriggerRuntime.shouldDebounce(source))
         }
     }
 


### PR DESCRIPTION
Hardens the trigger enum plumbing so a newly added `EventType` / `TriggerSource` can no longer be silently swallowed by an `else` arm.

Closes droidrun/mobilerun#407, closes droidrun/mobilerun#408, closes droidrun/mobilerun#409.

## Changes

**#407 — `handlePortalEvent` mapping is now compiler-enforced**
- The `EventType -> TriggerSource` mapping moved into `TriggerRuntime.triggerSourceFor`, an exhaustive `when` with no `else`. The four non-trigger members (`NOTIFICATION`, `PING`, `PONG`, `UNKNOWN`) map to `null` in one explicit, named arm — adding a new `EventType` without a decision here fails to compile.
- `triggerSourceFor` is `internal`, giving `handlePortalEvent`'s mapping its first unit tests.

**#408 — the two `isNotificationSource` functions renamed to what they decide**
- `TriggerEditorSupport.requiresNotificationAccess` — POSTED or REMOVED; gates the notification-listener permission (7 call sites).
- `TriggerRuntime.shouldDebounce` — POSTED only; routes into `NotificationDebounceBuffer`, which batches message title/text per sender — data that REMOVED events don't carry, so those evaluate immediately.
- The difference is intentional; both functions now say so in KDoc and cross-reference each other.

**#409 — `visibilityFor` no longer has a load-bearing `else`**
- The five sources that use the plain editor defaults (`BATTERY_LOW`, `BATTERY_OKAY`, `POWER_CONNECTED`, `POWER_DISCONNECTED`, `USER_PRESENT`) are listed explicitly; a new source now fails to compile until it gets a visibility decision, which `capabilitiesFor` / `defaultCooldownSecondsFor` derive from.

## Tests

Three new allow-list tests in `TriggerCoreTest`, mirroring the existing description-coverage pattern (`assertEquals(expected.keys, entries.toSet())`):
- visibility/capabilities/cooldown decision per `TriggerSource` (intended-defaults allow-list is explicit)
- `EventType -> TriggerSource` mapping incl. the intentionally-unmapped set
- notification-access + debounce decision per `TriggerSource`

No behavior change: all mapping arms, visibility results, and predicate outcomes are byte-identical to main. Full JVM suite passes except the pre-existing `SwitchTintResourceTest` failure, which fails identically on clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)