### PR TITLE
[DRO-2625] Prevent false SystemUI app exits

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/service/ForegroundApplicationTransitionTracker.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ForegroundApplicationTransitionTracker.kt
@@ -1,0 +1,47 @@
+package com.mobilerun.portal.service
+
+import com.mobilerun.portal.events.model.EventType
+import com.mobilerun.portal.events.model.PortalEvent
+import org.json.JSONObject
+
+/** Emits app transitions only when confirmed foreground application evidence advances. */
+internal class ForegroundApplicationTransitionTracker(
+    private val emit: (PortalEvent) -> Unit,
+) {
+    private var foregroundPackageName = ""
+
+    fun advance(packageName: String?) {
+        val nextPackage = packageName
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?: return
+        val previousPackage = foregroundPackageName
+        if (nextPackage == previousPackage) return
+
+        foregroundPackageName = nextPackage
+
+        if (previousPackage.isNotEmpty()) {
+            emit(
+                PortalEvent(
+                    type = EventType.APP_EXITED,
+                    payload = JSONObject().apply {
+                        put("package", previousPackage)
+                        put("next_package", nextPackage)
+                    },
+                ),
+            )
+        }
+
+        emit(
+            PortalEvent(
+                type = EventType.APP_ENTERED,
+                payload = JSONObject().apply {
+                    put("package", nextPackage)
+                    if (previousPackage.isNotEmpty()) {
+                        put("previous_package", previousPackage)
+                    }
+                },
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/service/ForegroundApplicationWindowResolver.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ForegroundApplicationWindowResolver.kt
@@ -1,0 +1,219 @@
+package com.mobilerun.portal.service
+
+import android.util.Log
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import java.util.Collections
+import java.util.IdentityHashMap
+
+/** Resolves accessibility window changes to confirmed foreground application evidence. */
+internal object ForegroundApplicationWindowResolver {
+    private const val TAG = "ForegroundAppWindow"
+    private const val UNDEFINED_WINDOW_ID = -1
+
+    internal data class Candidate(
+        val packageName: String,
+        val windowId: Int,
+    )
+
+    private data class WindowDescriptor(
+        val window: AccessibilityWindowInfo,
+        val id: Int,
+        val layer: Int,
+        val type: Int,
+        val isActive: Boolean,
+        val isFocused: Boolean,
+    )
+
+    private data class RootPackage(val value: String?)
+
+    fun resolve(
+        event: AccessibilityEvent?,
+        windowsProvider: () -> List<AccessibilityWindowInfo>?,
+    ): Candidate? {
+        if (event == null) return null
+
+        val eventType = readEventType(event) ?: return null
+        if (eventType != AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+            eventType != AccessibilityEvent.TYPE_WINDOWS_CHANGED
+        ) {
+            return null
+        }
+
+        val eventWindowId = readEventWindowId(event)
+        if (eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+            (eventWindowId == null || eventWindowId == UNDEFINED_WINDOW_ID)
+        ) {
+            return null
+        }
+
+        val windows = readWindows(windowsProvider) ?: return null
+        val uniqueWindows = uniqueByIdentity(windows)
+
+        try {
+            val descriptors = uniqueWindows.mapNotNull(::describeWindow)
+            val selected = when (eventType) {
+                AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ->
+                    selectStateChangedWindow(descriptors, eventWindowId!!)
+
+                AccessibilityEvent.TYPE_WINDOWS_CHANGED -> selectWindowsChangedWindow(descriptors)
+                else -> null
+            } ?: return null
+
+            val rootPackage = readRootPackage(selected) ?: return null
+            val authoritativePackage = rootPackage.value
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+            if (authoritativePackage != null) {
+                return Candidate(authoritativePackage, selected.id)
+            }
+
+            // Event metadata is only safe as a fallback when it describes the exact
+            // qualified application window whose root was inspected above.
+            if (eventWindowId == null ||
+                eventWindowId == UNDEFINED_WINDOW_ID ||
+                eventWindowId != selected.id
+            ) {
+                return null
+            }
+            val fallbackPackage = readEventPackage(event)
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
+                ?: return null
+            return Candidate(fallbackPackage, selected.id)
+        } finally {
+            uniqueWindows.forEach(::recycleWindow)
+        }
+    }
+
+    private fun selectStateChangedWindow(
+        descriptors: List<WindowDescriptor>,
+        eventWindowId: Int,
+    ): WindowDescriptor? {
+        return descriptors
+            .asSequence()
+            .filter {
+                it.id != UNDEFINED_WINDOW_ID &&
+                    it.id == eventWindowId &&
+                    it.type == AccessibilityWindowInfo.TYPE_APPLICATION &&
+                    (it.isFocused || it.isActive)
+            }
+            .sortedWith(
+                compareByDescending<WindowDescriptor> { it.isFocused }
+                    .thenByDescending { it.layer }
+                    .thenBy { it.id },
+            )
+            .firstOrNull()
+    }
+
+    private fun selectWindowsChangedWindow(
+        descriptors: List<WindowDescriptor>,
+    ): WindowDescriptor? {
+        val applications = descriptors.filter {
+            it.id != UNDEFINED_WINDOW_ID &&
+                it.type == AccessibilityWindowInfo.TYPE_APPLICATION
+        }
+        val focused = applications.filter { it.isFocused }
+        val eligible = focused.ifEmpty { applications.filter { it.isActive } }
+        return eligible.minWithOrNull(
+            compareByDescending<WindowDescriptor> { it.layer }
+                .thenBy { it.id },
+        )
+    }
+
+    private fun readEventType(event: AccessibilityEvent): Int? = try {
+        event.eventType
+    } catch (error: RuntimeException) {
+        logFailure("Unable to read accessibility event type", error)
+        null
+    }
+
+    private fun readEventWindowId(event: AccessibilityEvent): Int? = try {
+        event.windowId
+    } catch (error: RuntimeException) {
+        logFailure("Unable to read accessibility event window ID", error)
+        null
+    }
+
+    private fun readEventPackage(event: AccessibilityEvent): String? = try {
+        event.packageName?.toString()
+    } catch (error: RuntimeException) {
+        logFailure("Unable to read accessibility event package", error)
+        null
+    }
+
+    private fun readWindows(
+        windowsProvider: () -> List<AccessibilityWindowInfo>?,
+    ): List<AccessibilityWindowInfo>? = try {
+        windowsProvider()
+    } catch (error: RuntimeException) {
+        logFailure("Unable to read accessibility windows", error)
+        null
+    }
+
+    private fun uniqueByIdentity(
+        windows: List<AccessibilityWindowInfo>,
+    ): List<AccessibilityWindowInfo> {
+        val seen = Collections.newSetFromMap(
+            IdentityHashMap<AccessibilityWindowInfo, Boolean>(),
+        )
+        return windows.filter(seen::add)
+    }
+
+    private fun describeWindow(window: AccessibilityWindowInfo): WindowDescriptor? = try {
+        WindowDescriptor(
+            window = window,
+            id = window.id,
+            layer = window.layer,
+            type = window.type,
+            isActive = window.isActive,
+            isFocused = window.isFocused,
+        )
+    } catch (error: RuntimeException) {
+        logFailure("Unable to inspect accessibility window", error)
+        null
+    }
+
+    private fun readRootPackage(descriptor: WindowDescriptor): RootPackage? {
+        val root = try {
+            descriptor.window.root
+        } catch (error: RuntimeException) {
+            logFailure("Unable to read accessibility window root", error)
+            return null
+        } ?: return null
+
+        return try {
+            RootPackage(root.packageName?.toString())
+        } catch (error: RuntimeException) {
+            logFailure("Unable to read accessibility root package", error)
+            null
+        } finally {
+            recycleRoot(root)
+        }
+    }
+
+    private fun recycleWindow(window: AccessibilityWindowInfo) {
+        try {
+            window.recycle()
+        } catch (error: RuntimeException) {
+            logFailure("Unable to recycle accessibility window", error)
+        }
+    }
+
+    private fun recycleRoot(root: AccessibilityNodeInfo) {
+        try {
+            root.recycle()
+        } catch (error: RuntimeException) {
+            logFailure("Unable to recycle accessibility root", error)
+        }
+    }
+
+    private fun logFailure(message: String, error: RuntimeException) {
+        try {
+            Log.e(TAG, "$message: ${error.message}", error)
+        } catch (_: RuntimeException) {
+            // android.util.Log is unavailable in local JVM tests.
+        }
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunAccessibilityService.kt
@@ -39,13 +39,10 @@ import java.io.ByteArrayOutputStream
 import java.util.concurrent.CompletableFuture
 import com.mobilerun.portal.events.EventHub
 import com.mobilerun.portal.events.PortalWebSocketServer
-import com.mobilerun.portal.events.model.EventType
-import com.mobilerun.portal.events.model.PortalEvent
 import com.mobilerun.portal.keepalive.KeepAliveController
 import com.mobilerun.portal.keepalive.KeepAliveRecoveryActivity
 import com.mobilerun.portal.triggers.TriggerRuntime
 import androidx.core.app.NotificationCompat
-import org.json.JSONObject
 import java.util.Collections
 import java.util.IdentityHashMap
 
@@ -227,6 +224,8 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
     private var lastUpdateTime = 0L
     private var currentPackageName: String = ""
     private var currentActivityName: String = ""
+    private val foregroundApplicationTransitionTracker =
+        ForegroundApplicationTransitionTracker(EventHub::emit)
     private val visibleElements = mutableListOf<ElementNode>()
     private var visibleElementsSnapshotTimeMs = 0L
     private var visibleElementsSnapshotPackageName = ""
@@ -313,7 +312,6 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {
         val eventPackage = event?.packageName?.toString() ?: ""
         val eventClassName = event?.className?.toString() ?: ""
-        val previousPackage = currentPackageName
 
         // Detect package changes
         if (eventPackage.isNotEmpty() && eventPackage != currentPackageName && currentPackageName.isNotEmpty()) {
@@ -322,35 +320,16 @@ class MobilerunAccessibilityService : AccessibilityService(), ConfigManager.Conf
 
         if (eventPackage.isNotEmpty()) {
             currentPackageName = eventPackage
-            if (previousPackage.isNotEmpty() && previousPackage != eventPackage) {
-                EventHub.emit(
-                    PortalEvent(
-                        type = EventType.APP_EXITED,
-                        payload = JSONObject().apply {
-                            put("package", previousPackage)
-                            put("next_package", eventPackage)
-                        }
-                    )
-                )
-            }
-            if (previousPackage != eventPackage) {
-                EventHub.emit(
-                    PortalEvent(
-                        type = EventType.APP_ENTERED,
-                        payload = JSONObject().apply {
-                            put("package", eventPackage)
-                            if (previousPackage.isNotEmpty()) {
-                                put("previous_package", previousPackage)
-                            }
-                        }
-                    )
-                )
-            }
         }
+
+        val foregroundApplication = ForegroundApplicationWindowResolver.resolve(event) { windows }
+        foregroundApplicationTransitionTracker.advance(foregroundApplication?.packageName)
 
         // Capture activity name from TYPE_WINDOW_STATE_CHANGED events
         // These events typically indicate navigation to a new activity/screen
-        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
+        if (event?.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED &&
+            foregroundApplication != null
+        ) {
             if (eventClassName.isNotEmpty() && !eventClassName.startsWith("android.")) {
                 // Filter out Android system dialogs and only keep app activities
                 currentActivityName = eventClassName

--- a/app/src/test/java/com/mobilerun/portal/service/ForegroundApplicationTransitionTrackerTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ForegroundApplicationTransitionTrackerTest.kt
@@ -1,0 +1,84 @@
+package com.mobilerun.portal.service
+
+import com.mobilerun.portal.events.model.EventType
+import com.mobilerun.portal.events.model.PortalEvent
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ForegroundApplicationTransitionTrackerTest {
+    @Test
+    fun firstConfirmedApplicationEmitsOnlyEnteredAndSuppressesDuplicates() {
+        val events = mutableListOf<PortalEvent>()
+        val tracker = ForegroundApplicationTransitionTracker(events::add)
+
+        tracker.advance(null)
+        tracker.advance("")
+        tracker.advance("  $PORTAL  ")
+        tracker.advance(PORTAL)
+        tracker.advance(null)
+        tracker.advance(PORTAL)
+
+        assertEquals(listOf(EventType.APP_ENTERED), events.map(PortalEvent::type))
+        val payload = events.single().payload as JSONObject
+        assertEquals(PORTAL, payload.getString("package"))
+        assertFalse(payload.has("previous_package"))
+        assertFalse(payload.has("next_package"))
+    }
+
+    @Test
+    fun realApplicationChangeEmitsExitedThenEnteredWithExistingPayloadSchema() {
+        val events = mutableListOf<PortalEvent>()
+        val tracker = ForegroundApplicationTransitionTracker(events::add)
+        tracker.advance(PORTAL)
+        events.clear()
+
+        tracker.advance(SETTINGS)
+
+        assertEquals(
+            listOf(EventType.APP_EXITED, EventType.APP_ENTERED),
+            events.map(PortalEvent::type),
+        )
+        val exited = events[0].payload as JSONObject
+        assertEquals(PORTAL, exited.getString("package"))
+        assertEquals(SETTINGS, exited.getString("next_package"))
+        assertFalse(exited.has("previous_package"))
+
+        val entered = events[1].payload as JSONObject
+        assertEquals(SETTINGS, entered.getString("package"))
+        assertEquals(PORTAL, entered.getString("previous_package"))
+        assertFalse(entered.has("next_package"))
+    }
+
+    @Test
+    fun rejectedSystemUiEvidenceDoesNotLoseStateBeforeRealTransition() {
+        val events = mutableListOf<PortalEvent>()
+        val tracker = ForegroundApplicationTransitionTracker(events::add)
+
+        tracker.advance(PORTAL)
+        tracker.advance(null) // Notification shade / SystemUI is not application evidence.
+        tracker.advance(PORTAL)
+
+        assertEquals(listOf(EventType.APP_ENTERED), events.map(PortalEvent::type))
+
+        tracker.advance(SETTINGS)
+
+        assertEquals(
+            listOf(
+                EventType.APP_ENTERED,
+                EventType.APP_EXITED,
+                EventType.APP_ENTERED,
+            ),
+            events.map(PortalEvent::type),
+        )
+        val exited = events[1].payload as JSONObject
+        assertEquals(PORTAL, exited.getString("package"))
+        assertEquals(SETTINGS, exited.getString("next_package"))
+    }
+
+    private companion object {
+        const val PORTAL = "com.mobilerun.portal"
+        const val SETTINGS = "com.android.settings"
+    }
+}

--- a/app/src/test/java/com/mobilerun/portal/service/ForegroundApplicationWindowResolverTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ForegroundApplicationWindowResolverTest.kt
@@ -1,0 +1,464 @@
+package com.mobilerun.portal.service
+
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.accessibility.AccessibilityWindowInfo
+import com.mobilerun.portal.events.model.EventType
+import com.mobilerun.portal.events.model.PortalEvent
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ForegroundApplicationWindowResolverTest {
+    @Test
+    fun notificationAndContentEventsCannotReadWindowsOrProduceCandidates() {
+        listOf(
+            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED,
+            AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+        ).forEach { eventType ->
+            val event = event(type = eventType, windowId = 4, packageName = SYSTEM_UI)
+            var windowsRead = false
+
+            val candidate = ForegroundApplicationWindowResolver.resolve(event) {
+                windowsRead = true
+                emptyList()
+            }
+
+            assertNull(candidate)
+            assertFalse(windowsRead)
+            verify(exactly = 0) { event.windowId }
+        }
+    }
+
+    @Test
+    fun stateChangedUsesRootPackageFromExactActiveApplicationWindow() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            windowId = 7,
+            packageName = "untrusted.event.package",
+        )
+        val root = root(packageName = PORTAL)
+        val window = window(id = 7, layer = 3, active = true, root = root)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { listOf(window) }
+
+        assertEquals(
+            ForegroundApplicationWindowResolver.Candidate(PORTAL, 7),
+            candidate,
+        )
+        verify(exactly = 0) { event.packageName }
+        verify(exactly = 1) { window.root }
+        verify(exactly = 1) { root.packageName }
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun stateChangedRejectsStaleInactiveAndNonApplicationWindows() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            windowId = 10,
+            packageName = SYSTEM_UI,
+        )
+        val windows = listOf(
+            window(id = 10, layer = 9, active = false, focused = false, root = root(SYSTEM_UI)),
+            window(id = 11, layer = 8, active = true, root = root("other.app")),
+            window(
+                id = 10,
+                layer = 7,
+                type = AccessibilityWindowInfo.TYPE_SYSTEM,
+                focused = true,
+                root = root(SYSTEM_UI),
+            ),
+            window(
+                id = 10,
+                layer = 6,
+                type = AccessibilityWindowInfo.TYPE_INPUT_METHOD,
+                focused = true,
+                root = root("ime.package"),
+            ),
+            window(
+                id = 10,
+                layer = 5,
+                type = AccessibilityWindowInfo.TYPE_ACCESSIBILITY_OVERLAY,
+                focused = true,
+                root = root("overlay.package"),
+            ),
+        )
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { windows }
+
+        assertNull(candidate)
+        windows.forEach { window ->
+            verify(exactly = 0) { window.root }
+            verify(exactly = 1) { window.recycle() }
+        }
+        verify(exactly = 0) { event.packageName }
+    }
+
+    @Test
+    fun stateChangedAcceptsFocusedApplicationWindowThatIsNotActive() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            windowId = 12,
+        )
+        val root = root("focused.app")
+        val window = window(
+            id = 12,
+            layer = 4,
+            active = false,
+            focused = true,
+            root = root,
+        )
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { listOf(window) }
+
+        assertEquals("focused.app", candidate?.packageName)
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun windowsChangedPrefersFocusedThenLayerThenLowestId() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            windowId = 2,
+            packageName = "event.package",
+        )
+        val activeRoot = root("active.app")
+        val focusedLowRoot = root("focused.low")
+        val focusedHighIdRoot = root("focused.high.id")
+        val selectedRoot = root("focused.selected")
+        val active = window(id = 1, layer = 100, active = true, root = activeRoot)
+        val focusedLow = window(id = 8, layer = 3, focused = true, root = focusedLowRoot)
+        val focusedHighId = window(id = 3, layer = 8, focused = true, root = focusedHighIdRoot)
+        val selected = window(id = 2, layer = 8, focused = true, root = selectedRoot)
+        val windows = listOf(active, focusedLow, focusedHighId, selected)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { windows }
+
+        assertEquals(
+            ForegroundApplicationWindowResolver.Candidate("focused.selected", 2),
+            candidate,
+        )
+        verify(exactly = 1) { selected.root }
+        verify(exactly = 1) { selectedRoot.recycle() }
+        listOf(active, focusedLow, focusedHighId).forEach { window ->
+            verify(exactly = 0) { window.root }
+        }
+        listOf(activeRoot, focusedLowRoot, focusedHighIdRoot).forEach { root ->
+            verify(exactly = 0) { root.recycle() }
+        }
+        windows.forEach { window -> verify(exactly = 1) { window.recycle() } }
+        verify(exactly = 0) { event.packageName }
+    }
+
+    @Test
+    fun windowsChangedUsesHighestLayerAndLowestIdAmongActiveWindows() {
+        val event = event(type = AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 5)
+        val low = window(id = 1, layer = 1, active = true, root = root("low.app"))
+        val highId = window(id = 6, layer = 9, active = true, root = root("high.id.app"))
+        val selectedRoot = root("selected.app")
+        val selected = window(id = 5, layer = 9, active = true, root = selectedRoot)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) {
+            listOf(low, highId, selected)
+        }
+
+        assertEquals("selected.app", candidate?.packageName)
+        assertEquals(5, candidate?.windowId)
+        verify(exactly = 1) { selectedRoot.recycle() }
+        listOf(low, highId, selected).forEach { verify(exactly = 1) { it.recycle() } }
+    }
+
+    @Test
+    fun blankRootPackageFallsBackToExactlyMatchingEventPackage() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            windowId = 4,
+            packageName = " fallback.app ",
+        )
+        val root = root(packageName = "   ")
+        val window = window(id = 4, layer = 2, focused = true, root = root)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { listOf(window) }
+
+        assertEquals(
+            ForegroundApplicationWindowResolver.Candidate("fallback.app", 4),
+            candidate,
+        )
+        verify(exactly = 1) { event.packageName }
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun blankRootPackageCannotUseEventPackageFromDifferentWindow() {
+        val event = event(
+            type = AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            windowId = 99,
+            packageName = "stale.event.package",
+        )
+        val root = root(packageName = null)
+        val window = window(id = 4, layer = 2, active = true, root = root)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { listOf(window) }
+
+        assertNull(candidate)
+        verify(exactly = 0) { event.packageName }
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun missingOrFailingRootFailsClosedAndStillRecyclesHandles() {
+        val missingEvent = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 1)
+        val missingWindow = window(id = 1, layer = 1, active = true, root = null)
+
+        assertNull(
+            ForegroundApplicationWindowResolver.resolve(missingEvent) { listOf(missingWindow) },
+        )
+        verify(exactly = 1) { missingWindow.recycle() }
+
+        val failingEvent = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 2)
+        val failingRoot = root("ignored")
+        every { failingRoot.packageName } throws RuntimeException("stale root")
+        val failingWindow = window(id = 2, layer = 2, active = true, root = failingRoot)
+
+        assertNull(
+            ForegroundApplicationWindowResolver.resolve(failingEvent) { listOf(failingWindow) },
+        )
+        verify(exactly = 1) { failingRoot.recycle() }
+        verify(exactly = 1) { failingWindow.recycle() }
+
+        val throwingEvent = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 3)
+        val throwingWindow = window(id = 3, layer = 3, active = true, root = null)
+        every { throwingWindow.root } throws RuntimeException("window disconnected")
+
+        assertNull(
+            ForegroundApplicationWindowResolver.resolve(throwingEvent) { listOf(throwingWindow) },
+        )
+        verify(exactly = 1) { throwingWindow.recycle() }
+    }
+
+    @Test
+    fun malformedWindowIsSkippedWithoutBlockingValidWindowOrRecycling() {
+        val event = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 5)
+        val malformed = mockk<AccessibilityWindowInfo>()
+        every { malformed.id } throws RuntimeException("window unavailable")
+        every { malformed.recycle() } just runs
+        val validRoot = root("valid.app")
+        val valid = window(id = 5, layer = 1, active = true, root = validRoot)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) {
+            listOf(malformed, valid)
+        }
+
+        assertEquals("valid.app", candidate?.packageName)
+        verify(exactly = 1) { malformed.recycle() }
+        verify(exactly = 1) { valid.recycle() }
+        verify(exactly = 1) { validRoot.recycle() }
+    }
+
+    @Test
+    fun unavailableWindowListAndEventMetadataFailClosed() {
+        val event = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 1)
+
+        assertNull(ForegroundApplicationWindowResolver.resolve(event) { null })
+        assertNull(
+            ForegroundApplicationWindowResolver.resolve(event) {
+                throw RuntimeException("service disconnected")
+            },
+        )
+
+        val badType = mockk<AccessibilityEvent>()
+        every { badType.eventType } throws RuntimeException("recycled event")
+        assertNull(ForegroundApplicationWindowResolver.resolve(badType) { emptyList() })
+
+        val badWindowId = event(AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED, windowId = 1)
+        every { badWindowId.windowId } throws RuntimeException("missing ID")
+        assertNull(ForegroundApplicationWindowResolver.resolve(badWindowId) { emptyList() })
+    }
+
+    @Test
+    fun undefinedWindowDescriptorCannotAdvanceState() {
+        val undefinedRoot = root("com.example.undefined")
+        val undefinedWindow = window(
+            id = -1,
+            layer = 10,
+            active = true,
+            root = undefinedRoot,
+        )
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(
+            event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = -1),
+        ) {
+            listOf(undefinedWindow)
+        }
+
+        assertNull(candidate)
+        verify(exactly = 0) { undefinedWindow.root }
+        verify(exactly = 0) { undefinedRoot.recycle() }
+        verify(exactly = 1) { undefinedWindow.recycle() }
+    }
+
+    @Test
+    fun duplicateWindowIdentityIsInspectedAndRecycledExactlyOnce() {
+        val event = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 1)
+        val root = root(PORTAL)
+        val window = window(id = 1, layer = 1, active = true, root = root)
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) {
+            listOf(window, window)
+        }
+
+        assertEquals(PORTAL, candidate?.packageName)
+        verify(exactly = 1) { window.id }
+        verify(exactly = 1) { window.root }
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun recyclingFailuresDoNotDiscardOtherwiseConfirmedCandidate() {
+        val event = event(AccessibilityEvent.TYPE_WINDOWS_CHANGED, windowId = 1)
+        val root = root(PORTAL)
+        every { root.recycle() } throws RuntimeException("root already stale")
+        val window = window(id = 1, layer = 1, active = true, root = root)
+        every { window.recycle() } throws RuntimeException("window already stale")
+
+        val candidate = ForegroundApplicationWindowResolver.resolve(event) { listOf(window) }
+
+        assertEquals(PORTAL, candidate?.packageName)
+        verify(exactly = 1) { root.recycle() }
+        verify(exactly = 1) { window.recycle() }
+    }
+
+    @Test
+    fun portalSystemUiNotificationPortalSequenceEmitsNoFalseTransition() {
+        val emitted = mutableListOf<PortalEvent>()
+        val tracker = ForegroundApplicationTransitionTracker(emitted::add)
+        val portalRoot = root(PORTAL)
+        val portalWindow = window(id = 1, layer = 1, active = true, root = portalRoot)
+        val portalEvent = event(
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            windowId = 1,
+            packageName = PORTAL,
+        )
+        tracker.advance(
+            ForegroundApplicationWindowResolver.resolve(portalEvent) {
+                listOf(portalWindow)
+            }?.packageName,
+        )
+
+        val systemRoot = root(SYSTEM_UI)
+        val systemWindow = window(
+            id = 2,
+            layer = 20,
+            type = AccessibilityWindowInfo.TYPE_SYSTEM,
+            active = true,
+            focused = true,
+            root = systemRoot,
+        )
+        val systemEvent = event(
+            AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+            windowId = 2,
+            packageName = SYSTEM_UI,
+        )
+        tracker.advance(
+            ForegroundApplicationWindowResolver.resolve(systemEvent) {
+                listOf(systemWindow)
+            }?.packageName,
+        )
+
+        var notificationReadWindows = false
+        val notificationEvent = event(
+            AccessibilityEvent.TYPE_NOTIFICATION_STATE_CHANGED,
+            windowId = 2,
+            packageName = SYSTEM_UI,
+        )
+        tracker.advance(
+            ForegroundApplicationWindowResolver.resolve(notificationEvent) {
+                notificationReadWindows = true
+                emptyList()
+            }?.packageName,
+        )
+
+        val returnedPortalRoot = root(PORTAL)
+        val returnedPortalWindow = window(
+            id = 1,
+            layer = 1,
+            focused = true,
+            root = returnedPortalRoot,
+        )
+        val returnedPortalEvent = event(
+            AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+            windowId = 1,
+            packageName = PORTAL,
+        )
+        tracker.advance(
+            ForegroundApplicationWindowResolver.resolve(returnedPortalEvent) {
+                listOf(returnedPortalWindow)
+            }?.packageName,
+        )
+
+        assertEquals(listOf(EventType.APP_ENTERED), emitted.map(PortalEvent::type))
+        assertFalse(notificationReadWindows)
+        verify(exactly = 1) { portalRoot.recycle() }
+        verify(exactly = 1) { portalWindow.recycle() }
+        verify(exactly = 0) { systemWindow.root }
+        verify(exactly = 0) { systemRoot.recycle() }
+        verify(exactly = 1) { systemWindow.recycle() }
+        verify(exactly = 1) { returnedPortalRoot.recycle() }
+        verify(exactly = 1) { returnedPortalWindow.recycle() }
+    }
+
+    private fun event(
+        type: Int,
+        windowId: Int = -1,
+        packageName: String? = null,
+    ): AccessibilityEvent {
+        return mockk<AccessibilityEvent>().also { event ->
+            every { event.eventType } returns type
+            every { event.windowId } returns windowId
+            every { event.packageName } returns packageName
+        }
+    }
+
+    private fun root(packageName: String?): AccessibilityNodeInfo {
+        return mockk<AccessibilityNodeInfo>().also { root ->
+            every { root.packageName } returns packageName
+            every { root.recycle() } just runs
+        }
+    }
+
+    private fun window(
+        id: Int,
+        layer: Int,
+        type: Int = AccessibilityWindowInfo.TYPE_APPLICATION,
+        active: Boolean = false,
+        focused: Boolean = false,
+        root: AccessibilityNodeInfo?,
+    ): AccessibilityWindowInfo {
+        return mockk<AccessibilityWindowInfo>().also { window ->
+            every { window.id } returns id
+            every { window.layer } returns layer
+            every { window.type } returns type
+            every { window.isActive } returns active
+            every { window.isFocused } returns focused
+            every { window.root } returns root
+            every { window.recycle() } just runs
+        }
+    }
+
+    private companion object {
+        const val PORTAL = "com.mobilerun.portal"
+        const val SYSTEM_UI = "com.android.systemui"
+    }
+}


### PR DESCRIPTION
## Summary

- validate app transitions only from confirmed active/focused `TYPE_APPLICATION` windows
- keep foreground transition state separate from accessibility-event package/cache bookkeeping
- preserve existing event names, payloads, trigger schemas, raw event handlers, and #155 multi-root behavior
- suppress notification-shade/SystemUI noise while retaining genuine app transitions such as Portal ↔ Settings, launcher, and PermissionController

Internal companion: https://github.com/droidrun/mobilerun-portal-internal/pull/78

## Behavior

- the first confirmed foreground app emits only `APP_ENTERED`
- a genuine A → B transition emits one `APP_EXITED`, then one `APP_ENTERED`
- repeated packages and Portal → SystemUI → Portal notification-shade sequences emit nothing
- `currentActivityName` advances only with the same confirmed application-window evidence

## Validation

Host:
- focused resolver/tracker tests: 18 passed
- `:app:testDebugUnitTest`: 551 tests; only the documented pre-existing `SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates` failure
- `lintDebug`, `:app:assembleDebug`, and `git diff --check`: passed

Android 16 / API 36:
- instrumentation: 7/7 passed
- UI-driven trigger smoke: all 12 assertions passed
- notification shade held open across a clock update: zero `APP_*` events and zero app-trigger runs
- Portal ↔ Settings and Portal ↔ PermissionController: one exact transition pair in each direction
- notification debounce/removal and legacy duplicate suppression: passed
- sanitized crash/ANR/accessibility/listener/WebSocket log gate: clean

Android 15 / API 35 (16 KB pages):
- instrumentation: 7/7 passed
- the same 12 trigger assertions and genuine-transition checks passed
- sanitized log and cleanup gates: clean

Both device sessions were local-only with a blank launch token; cloud state was disconnected with no stored token or active task.

Related to DRO-2625