### PR TITLE
[DRO-2628] Add Portal deep-link RPC support

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,6 +3,32 @@
 
     <application>
         <activity
+            android:name=".core.DeepLinkFixtureActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="deep-link-fixture"
+                    android:scheme="${applicationId}" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="${applicationId}.action.DEEP_LINK_FIXTURE" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="deep-link-fixture"
+                    android:scheme="${applicationId}" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".core.PopupWindowFixtureActivity"
             android:exported="false"
             android:theme="@android:style/Theme.Material.Light.NoActionBar" />

--- a/app/src/debug/java/com/mobilerun/portal/core/DeepLinkFixtureActivity.kt
+++ b/app/src/debug/java/com/mobilerun/portal/core/DeepLinkFixtureActivity.kt
@@ -1,0 +1,65 @@
+package com.mobilerun.portal.core
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+
+/** Debug-only target for deterministic deep-link RPC verification. */
+class DeepLinkFixtureActivity : Activity() {
+
+    private lateinit var actionView: TextView
+    private lateinit var dataView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(
+            LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER
+                setPadding(dp(24), dp(24), dp(24), dp(24))
+                setBackgroundColor(Color.WHITE)
+
+                addView(markerView(FIXTURE_MARKER))
+                actionView = markerView("")
+                addView(actionView)
+                dataView = markerView("")
+                addView(dataView)
+            },
+        )
+        renderIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        renderIntent(intent)
+    }
+
+    private fun renderIntent(intent: Intent) {
+        val action = intent.action.orEmpty()
+        val data = intent.dataString.orEmpty()
+        actionView.text = "$ACTION_MARKER$action"
+        actionView.contentDescription = "$ACTION_MARKER$action"
+        dataView.text = "$DATA_MARKER$data"
+        dataView.contentDescription = "$DATA_MARKER$data"
+    }
+
+    private fun markerView(marker: String): TextView = TextView(this).apply {
+        text = marker
+        contentDescription = marker
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+    }
+
+    private fun dp(value: Int): Int = (value * resources.displayMetrics.density).toInt()
+
+    companion object {
+        const val FIXTURE_MARKER = "mobilerun-deep-link-fixture"
+        const val ACTION_MARKER = "mobilerun-deep-link-action:"
+        const val DATA_MARKER = "mobilerun-deep-link-data:"
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
+++ b/app/src/main/java/com/mobilerun/portal/api/ApiHandler.kt
@@ -1,8 +1,10 @@
 package com.mobilerun.portal.api
 
 import android.accessibilityservice.AccessibilityService
+import android.app.ActivityOptions
 import android.app.ActivityManager
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.pm.ApplicationInfo
@@ -741,6 +743,44 @@ class ApiHandler(
         } catch (e: Exception) {
             Log.e("ApiHandler", "Error starting app", e)
             ApiResponse.Error("Error starting app: ${e.message}")
+        }
+    }
+
+    fun openDeepLink(
+        displayId: Int,
+        packageName: String?,
+        action: String?,
+        deepLink: String,
+    ): ApiResponse {
+        if (!stateRepo.hasAccessibilityService) {
+            return ApiResponse.Error(APP_LAUNCH_REQUIRES_ACCESSIBILITY)
+        }
+        if (deepLink.isBlank() || deepLink.trim() == "null") {
+            return ApiResponse.Error("Missing required param: 'deepLink'")
+        }
+        if (displayId < 0) {
+            return ApiResponse.Error("Invalid displayId: must be >= 0")
+        }
+
+        return try {
+            val intent = Intent().apply {
+                this.action = action?.takeIf { it.isNotBlank() } ?: Intent.ACTION_VIEW
+                data = Uri.parse(deepLink)
+                packageName?.takeIf { it.isNotBlank() }?.let(::setPackage)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            val options = ActivityOptions.makeBasic()
+            options.setLaunchDisplayId(displayId)
+            context.startActivity(intent, options.toBundle())
+            ApiResponse.Success("Deep link opened")
+        } catch (_: ActivityNotFoundException) {
+            ApiResponse.Error("No activity found to handle deep link")
+        } catch (_: SecurityException) {
+            ApiResponse.Error("Deep link launch not permitted")
+        } catch (_: IllegalArgumentException) {
+            ApiResponse.Error("Invalid deep link launch")
+        } catch (_: Exception) {
+            ApiResponse.Error("Failed to open deep link")
         }
     }
 

--- a/app/src/main/java/com/mobilerun/portal/service/ActionDispatcher.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ActionDispatcher.kt
@@ -111,6 +111,32 @@ class ActionDispatcher(
                 apiHandler.startApp(pkg, finalActivity)
             }
 
+            "app/deep-link" -> {
+                val deepLink =
+                    if (params.has("deepLink") && !params.isNull("deepLink")) {
+                        params.optString("deepLink", "")
+                    } else {
+                        ""
+                    }
+                if (deepLink.isBlank() || deepLink.trim() == "null") {
+                    return ApiResponse.Error("Missing required param: 'deepLink'")
+                }
+
+                val displayId = params.optInt("displayId", 0)
+                if (displayId < 0) {
+                    return ApiResponse.Error("Invalid displayId: must be >= 0")
+                }
+
+                val packageName =
+                    if (hasCanonicalPackage(params)) {
+                        optionalString(params, "package")
+                    } else {
+                        optionalString(params, "packageName")
+                    }
+                val intentAction = optionalString(params, "action")
+                apiHandler.openDeepLink(displayId, packageName, intentAction, deepLink)
+            }
+
             "app/stop" -> {
                 val pkg = params.optString("package", "").ifEmpty {
                     params.optString("packageName", "")
@@ -488,5 +514,17 @@ class ActionDispatcher(
             is TriggerApiResult.Error -> ApiResponse.Error(result.message)
             is TriggerApiResult.Success -> onSuccess(result.value)
         }
+    }
+
+    private fun optionalString(params: JSONObject, key: String): String? {
+        if (!params.has(key) || params.isNull(key)) return null
+        return params.optString(key, "").trim().takeUnless {
+            it.isEmpty() || it == "null"
+        }
+    }
+
+    private fun hasCanonicalPackage(params: JSONObject): Boolean {
+        if (!params.has("package") || params.isNull("package")) return false
+        return params.optString("package", "").trim() != "null"
     }
 }

--- a/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
@@ -36,6 +36,12 @@ import java.net.URI
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
 
+internal fun shouldRedactReverseRequestPayload(normalizedMethod: String): Boolean =
+    normalizedMethod == "clipboard/set" || normalizedMethod == "app/deep-link"
+
+internal fun shouldRedactReverseResponsePayload(normalizedMethod: String): Boolean =
+    normalizedMethod == "clipboard/get" || normalizedMethod == "app/deep-link"
+
 class ReverseConnectionService : Service() {
 
     companion object {
@@ -599,6 +605,7 @@ class ReverseConnectionService : Service() {
         if (message == null) return
 
         var id: Any? = null
+        var methodForResponseLogging: String? = null
 
         try {
             // Check if the message is a valid JSON before parsing
@@ -615,9 +622,10 @@ class ReverseConnectionService : Service() {
             val method = json.optString("method", "")
             val normalizedMethod =
                 method.removePrefix("/action/").removePrefix("action.").removePrefix("/")
+            methodForResponseLogging = normalizedMethod
 
-            if (normalizedMethod == "clipboard/set") {
-                Log.d(TAG, "Received message: clipboard/set (id=$id, params=<redacted>)")
+            if (shouldRedactReverseRequestPayload(normalizedMethod)) {
+                Log.d(TAG, "Received message: $normalizedMethod (id=$id, params=<redacted>)")
             } else {
                 val logMsg = if (message.length > 200) message.take(200) + "..." else message
                 Log.d(TAG, "Received message: $logMsg")
@@ -637,7 +645,7 @@ class ReverseConnectionService : Service() {
             val params = json.optJSONObject("params") ?: JSONObject()
 
             // Truncate params log to avoid spamming with large SDP/ICE payloads
-            val paramsLog = if (normalizedMethod == "clipboard/set") {
+            val paramsLog = if (shouldRedactReverseRequestPayload(normalizedMethod)) {
                 "<redacted>"
             } else {
                 params.toString().let { if (it.length > 100) it.take(100) + "..." else it }
@@ -649,7 +657,7 @@ class ReverseConnectionService : Service() {
                 val error =
                     "Accessibility Service not ready. Only stream/*, webrtc/*, screen/keepAwake/*, global, and triggers/* are available."
                 Log.e(TAG, error)
-                sendErrorResponse(client, id, error)
+                sendErrorResponse(client, id, error, normalizedMethod)
                 return
             }
 
@@ -676,7 +684,12 @@ class ReverseConnectionService : Service() {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error processing message", e)
-            sendErrorResponse(client, id, e.message ?: "unknown exception")
+            sendErrorResponse(
+                client,
+                id,
+                e.message ?: "unknown exception",
+                methodForResponseLogging,
+            )
         }
     }
 
@@ -706,7 +719,12 @@ class ReverseConnectionService : Service() {
         } catch (e: Exception) {
             val elapsedMs = SystemClock.elapsedRealtime() - dispatchStartedAtMs
             Log.e(TAG, "Failed $method (id=$requestId, elapsedMs=$elapsedMs)", e)
-            sendErrorResponse(client, requestId, e.message ?: "unknown exception")
+            sendErrorResponse(
+                client,
+                requestId,
+                e.message ?: "unknown exception",
+                normalizedMethod,
+            )
         }
     }
 
@@ -723,8 +741,11 @@ class ReverseConnectionService : Service() {
         try {
             val payload = response.toJson(requestId)
             client.send(payload)
-            if (normalizedMethod == "clipboard/get") {
-                Log.d(TAG, "Sent response for clipboard/get (id=$requestId, payload=<redacted>)")
+            if (
+                normalizedMethod != null &&
+                shouldRedactReverseResponsePayload(normalizedMethod)
+            ) {
+                Log.d(TAG, "Sent response for $normalizedMethod (id=$requestId, payload=<redacted>)")
             } else {
                 val logPayload = if (payload.length > 200) payload.take(200) + "..." else payload
                 Log.d(TAG, "Sent response: $logPayload")
@@ -734,9 +755,14 @@ class ReverseConnectionService : Service() {
         }
     }
 
-    private fun sendErrorResponse(client: WebSocketClient, requestId: Any?, message: String) {
+    private fun sendErrorResponse(
+        client: WebSocketClient,
+        requestId: Any?,
+        message: String,
+        normalizedMethod: String? = null,
+    ) {
         if (requestId == null) return
-        sendResponse(client, ApiResponse.Error(message), requestId)
+        sendResponse(client, ApiResponse.Error(message), requestId, normalizedMethod)
     }
 
     private fun buildHeadlessActionDispatcher(): ActionDispatcher {

--- a/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/api/ApiHandlerTest.kt
@@ -1,10 +1,14 @@
 package com.mobilerun.portal.api
 
+import android.app.ActivityOptions
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
 import android.view.KeyEvent
 import android.util.Base64
 import com.mobilerun.portal.core.StateRepository
@@ -33,6 +37,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class ApiHandlerTest {
@@ -450,6 +455,124 @@ class ApiHandlerTest {
         verify(exactly = 1) { anyConstructed<Intent>().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
         verify(exactly = 1) { context.startActivity(any()) }
         verify(exactly = 0) { packageManager.getLaunchIntentForPackage(any()) }
+    }
+
+    @Test
+    fun openDeepLink_requiresAccessibility() {
+        val context = mockk<Context>(relaxed = true)
+        val handler =
+            createHandler(
+                stateRepo = StateRepository(service = null),
+                ime = null,
+                context = context,
+            )
+
+        assertEquals(
+            ApiResponse.Error("App launch requires Accessibility service"),
+            handler.openDeepLink(0, null, null, "example://private-token"),
+        )
+
+        verify(exactly = 0) { context.startActivity(any<Intent>(), any<Bundle>()) }
+    }
+
+    @Test
+    fun openDeepLink_rejectsBlankLinkAndNegativeDisplayBeforeLaunch() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { stateRepo.hasAccessibilityService } returns true
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            handler.openDeepLink(0, null, null, "  "),
+        )
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            handler.openDeepLink(0, null, null, "null"),
+        )
+        assertEquals(
+            ApiResponse.Error("Invalid displayId: must be >= 0"),
+            handler.openDeepLink(-1, null, null, "example://path"),
+        )
+        verify(exactly = 0) { context.startActivity(any<Intent>(), any<Bundle>()) }
+    }
+
+    @Test
+    fun openDeepLink_defaultsToViewAndForwardsDataFlagsAndDisplay() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { stateRepo.hasAccessibilityService } returns true
+        val mocks = prepareDeepLinkLaunchMocks("example://path", displayId = 0)
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+
+        assertEquals(
+            ApiResponse.Success("Deep link opened"),
+            handler.openDeepLink(0, null, null, "example://path"),
+        )
+
+        verify(exactly = 1) { anyConstructed<Intent>().setAction(Intent.ACTION_VIEW) }
+        verify(exactly = 1) { anyConstructed<Intent>().setData(mocks.uri) }
+        verify(exactly = 0) { anyConstructed<Intent>().setPackage(any()) }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        verify(exactly = 1) { mocks.options.setLaunchDisplayId(0) }
+        verify(exactly = 1) { context.startActivity(any<Intent>(), mocks.bundle) }
+    }
+
+    @Test
+    fun openDeepLink_forwardsCustomActionPackageAndDisplay() {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { stateRepo.hasAccessibilityService } returns true
+        val mocks = prepareDeepLinkLaunchMocks("example://path", displayId = 4)
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+
+        assertEquals(
+            ApiResponse.Success("Deep link opened"),
+            handler.openDeepLink(4, "com.example", "com.example.OPEN", "example://path"),
+        )
+
+        verify(exactly = 1) { anyConstructed<Intent>().setAction("com.example.OPEN") }
+        verify(exactly = 1) { anyConstructed<Intent>().setData(mocks.uri) }
+        verify(exactly = 1) { anyConstructed<Intent>().setPackage("com.example") }
+        verify(exactly = 1) {
+            anyConstructed<Intent>().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        verify(exactly = 1) { mocks.options.setLaunchDisplayId(4) }
+        verify(exactly = 1) { context.startActivity(any<Intent>(), mocks.bundle) }
+    }
+
+    @Test
+    fun openDeepLink_returnsStableErrorWhenNoHandlerExists() {
+        assertDeepLinkStartFailure(
+            ActivityNotFoundException("secret://must-not-leak"),
+            "No activity found to handle deep link",
+        )
+    }
+
+    @Test
+    fun openDeepLink_returnsStableErrorWhenLaunchIsNotPermitted() {
+        assertDeepLinkStartFailure(
+            SecurityException("secret://must-not-leak"),
+            "Deep link launch not permitted",
+        )
+    }
+
+    @Test
+    fun openDeepLink_returnsStableErrorForInvalidLaunch() {
+        assertDeepLinkStartFailure(
+            IllegalArgumentException("secret://must-not-leak"),
+            "Invalid deep link launch",
+        )
+    }
+
+    @Test
+    fun openDeepLink_returnsStableErrorForUnexpectedFailure() {
+        assertDeepLinkStartFailure(
+            IllegalStateException("secret://must-not-leak"),
+            "Failed to open deep link",
+        )
     }
 
     @Test
@@ -1253,5 +1376,49 @@ class ApiHandlerTest {
             appVersionProvider = { "test-version" },
             context = context,
         )
+    }
+
+    private data class DeepLinkLaunchMocks(
+        val uri: Uri,
+        val options: ActivityOptions,
+        val bundle: Bundle,
+    )
+
+    private fun prepareDeepLinkLaunchMocks(
+        deepLink: String,
+        displayId: Int,
+    ): DeepLinkLaunchMocks {
+        mockkConstructor(Intent::class)
+        mockkStatic(Uri::class)
+        mockkStatic(ActivityOptions::class)
+
+        val uri = mockk<Uri>()
+        val options = mockk<ActivityOptions>()
+        val bundle = mockk<Bundle>()
+        every { Uri.parse(deepLink) } returns uri
+        every { anyConstructed<Intent>().setAction(any()) } returns mockk(relaxed = true)
+        every { anyConstructed<Intent>().setData(uri) } returns mockk(relaxed = true)
+        every { anyConstructed<Intent>().setPackage(any()) } returns mockk(relaxed = true)
+        every {
+            anyConstructed<Intent>().addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        } returns mockk(relaxed = true)
+        every { ActivityOptions.makeBasic() } returns options
+        every { options.setLaunchDisplayId(displayId) } returns options
+        every { options.toBundle() } returns bundle
+        return DeepLinkLaunchMocks(uri, options, bundle)
+    }
+
+    private fun assertDeepLinkStartFailure(error: Exception, expectedMessage: String) {
+        val stateRepo = mockk<StateRepository>(relaxed = true)
+        val context = mockk<Context>(relaxed = true)
+        every { stateRepo.hasAccessibilityService } returns true
+        val mocks = prepareDeepLinkLaunchMocks("secret://must-not-leak", displayId = 0)
+        every { context.startActivity(any<Intent>(), mocks.bundle) } throws error
+        val handler = createHandler(stateRepo = stateRepo, ime = null, context = context)
+
+        val response = handler.openDeepLink(0, null, null, "secret://must-not-leak")
+
+        assertEquals(ApiResponse.Error(expectedMessage), response)
+        assertFalse((response as ApiResponse.Error).message.contains("secret://"))
     }
 }

--- a/app/src/test/java/com/mobilerun/portal/service/ActionDispatcherTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ActionDispatcherTest.kt
@@ -75,6 +75,145 @@ class ActionDispatcherTest {
     }
 
     @Test
+    fun dispatch_deepLink_routesExplicitParams() {
+        val apiHandler = mockk<ApiHandler>()
+        every {
+            apiHandler.openDeepLink(
+                3,
+                "com.example",
+                "com.example.OPEN",
+                "example://account/token",
+            )
+        } returns ApiResponse.Success("Deep link opened")
+
+        val response =
+            ActionDispatcher(apiHandler).dispatch(
+                "app/deep-link",
+                JSONObject().apply {
+                    put("displayId", 3)
+                    put("package", "com.example")
+                    put("action", "com.example.OPEN")
+                    put("deepLink", "example://account/token")
+                },
+            )
+
+        assertEquals(ApiResponse.Success("Deep link opened"), response)
+        verify(exactly = 1) {
+            apiHandler.openDeepLink(
+                3,
+                "com.example",
+                "com.example.OPEN",
+                "example://account/token",
+            )
+        }
+    }
+
+    @Test
+    fun dispatch_deepLink_defaultsDisplayAndOptionalParams() {
+        val apiHandler = mockk<ApiHandler>()
+        every {
+            apiHandler.openDeepLink(0, null, null, "example://path")
+        } returns ApiResponse.Success("Deep link opened")
+
+        val response =
+            ActionDispatcher(apiHandler).dispatch(
+                "app/deep-link",
+                JSONObject().put("deepLink", "example://path"),
+            )
+
+        assertEquals(ApiResponse.Success("Deep link opened"), response)
+        verify(exactly = 1) {
+            apiHandler.openDeepLink(0, null, null, "example://path")
+        }
+    }
+
+    @Test
+    fun dispatch_deepLink_acceptsPackageNameAliasWhenCanonicalPackageIsAbsent() {
+        val apiHandler = mockk<ApiHandler>()
+        every {
+            apiHandler.openDeepLink(0, "com.example", null, "example://path")
+        } returns ApiResponse.Success("Deep link opened")
+
+        val response =
+            ActionDispatcher(apiHandler).dispatch(
+                "app/deep-link",
+                JSONObject().apply {
+                    put("packageName", "com.example")
+                    put("action", JSONObject.NULL)
+                    put("deepLink", "example://path")
+                },
+            )
+
+        assertEquals(ApiResponse.Success("Deep link opened"), response)
+        verify(exactly = 1) {
+            apiHandler.openDeepLink(0, "com.example", null, "example://path")
+        }
+    }
+
+    @Test
+    fun dispatch_deepLink_blankCanonicalPackageKeepsLaunchUnpinned() {
+        val apiHandler = mockk<ApiHandler>()
+        every {
+            apiHandler.openDeepLink(0, null, null, "example://path")
+        } returns ApiResponse.Success("Deep link opened")
+
+        val response =
+            ActionDispatcher(apiHandler).dispatch(
+                "app/deep-link",
+                JSONObject().apply {
+                    put("package", " ")
+                    put("packageName", "com.example")
+                    put("deepLink", "example://path")
+                },
+            )
+
+        assertEquals(ApiResponse.Success("Deep link opened"), response)
+        verify(exactly = 1) {
+            apiHandler.openDeepLink(0, null, null, "example://path")
+        }
+    }
+
+    @Test
+    fun dispatch_deepLink_rejectsMissingOrBlankLinkAndNegativeDisplay() {
+        val apiHandler = mockk<ApiHandler>(relaxed = true)
+        val dispatcher = ActionDispatcher(apiHandler)
+
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            dispatcher.dispatch("app/deep-link", JSONObject()),
+        )
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            dispatcher.dispatch(
+                "app/deep-link",
+                JSONObject().put("deepLink", "  "),
+            ),
+        )
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            dispatcher.dispatch(
+                "app/deep-link",
+                JSONObject().put("deepLink", JSONObject.NULL),
+            ),
+        )
+        assertEquals(
+            ApiResponse.Error("Missing required param: 'deepLink'"),
+            dispatcher.dispatch(
+                "app/deep-link",
+                JSONObject().put("deepLink", "null"),
+            ),
+        )
+        assertEquals(
+            ApiResponse.Error("Invalid displayId: must be >= 0"),
+            dispatcher.dispatch(
+                "app/deep-link",
+                JSONObject().put("deepLink", "example://path").put("displayId", -1),
+            ),
+        )
+        verify(exactly = 0) { apiHandler.openDeepLink(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun dispatch_input_defaultsClearToTrue_andSupportsAliases() {
         val apiHandler = mockk<ApiHandler>()
         every { apiHandler.keyboardInput("SGVsbG8=", true) } returns ApiResponse.Success("ok")

--- a/app/src/test/java/com/mobilerun/portal/service/HeadlessActionSupportTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/HeadlessActionSupportTest.kt
@@ -34,6 +34,7 @@ class HeadlessActionSupportTest {
         assertFalse(HeadlessActionSupport.isAllowed("tap"))
         assertFalse(HeadlessActionSupport.isAllowed("packages"))
         assertFalse(HeadlessActionSupport.isAllowed("state"))
+        assertFalse(HeadlessActionSupport.isAllowed("app/deep-link"))
     }
 }
 

--- a/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionLoggingTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionLoggingTest.kt
@@ -1,0 +1,23 @@
+package com.mobilerun.portal.service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReverseConnectionLoggingTest {
+    @Test
+    fun requestRedaction_coversSensitiveWritePayloads() {
+        assertTrue(shouldRedactReverseRequestPayload("clipboard/set"))
+        assertTrue(shouldRedactReverseRequestPayload("app/deep-link"))
+        assertFalse(shouldRedactReverseRequestPayload("clipboard/get"))
+        assertFalse(shouldRedactReverseRequestPayload("app"))
+    }
+
+    @Test
+    fun responseRedaction_coversSensitiveReadAndDeepLinkPayloads() {
+        assertTrue(shouldRedactReverseResponsePayload("clipboard/get"))
+        assertTrue(shouldRedactReverseResponsePayload("app/deep-link"))
+        assertFalse(shouldRedactReverseResponsePayload("clipboard/set"))
+        assertFalse(shouldRedactReverseResponsePayload("app"))
+    }
+}

--- a/docs/local-api.md
+++ b/docs/local-api.md
@@ -68,6 +68,7 @@ Response format:
 | `swipe` | `startX`, `startY`, `endX`, `endY`, `duration` | Duration in ms (optional) |
 | `global` | `action` | Accessibility global action ID |
 | `app` | `package`, `activity`, `stopBeforeLaunch` | `activity` optional; `stopBeforeLaunch` defaults to `false` |
+| `app/deep-link` | `deepLink`, `displayId`, `package`, `action` | Opens an implicit URI intent; `displayId` defaults to `0`, `action` defaults to `android.intent.action.VIEW`, and `package` is optional (`packageName` is also accepted) |
 | `app/stop` | `package` | Best-effort stop (non-privileged app) |
 | `keyboard/input` | `base64_text`, `clear` | `clear` defaults to `true` |
 | `keyboard/clear` | - | Clears focused input |
@@ -158,6 +159,17 @@ curl -X POST \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -d "x=200&y=400" \
   http://localhost:8080/tap
+```
+
+Deep links are authenticated and require Accessibility, like `app` launches. Android resolves
+the URI and any optional package pin; custom schemes are supported.
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  --data-urlencode "deepLink=myapp://path" \
+  --data-urlencode "displayId=0" \
+  http://localhost:8080/app/deep-link
 ```
 
 ## ContentProvider (ADB)

--- a/docs/reverse-connection.md
+++ b/docs/reverse-connection.md
@@ -102,6 +102,7 @@ Notes:
 Reverse connection supports the same app commands as local WebSocket:
 
 - `app` with optional `stopBeforeLaunch` (default `false`)
+- `app/deep-link` with required `deepLink`, optional `package`, optional `action`, and `displayId` (default `0`)
 - `app/stop` to request a best-effort stop
 
 Example:
@@ -117,6 +118,24 @@ Example:
 ```json
 {
   "id": "2",
+  "method": "app/deep-link",
+  "params": {
+    "displayId": 0,
+    "package": "com.example.app",
+    "action": "android.intent.action.VIEW",
+    "deepLink": "myapp://path"
+  }
+}
+```
+
+Blank `package` leaves resolution unpinned, and `packageName` is accepted as a direct-RPC
+compatibility alias. Blank `action` defaults to `android.intent.action.VIEW`. Arbitrary custom
+schemes are passed to Android's resolver. Deep-link request and response payloads are redacted
+from reverse-connection logs because URIs can contain credentials.
+
+```json
+{
+  "id": "3",
   "method": "app/stop",
   "params": { "package": "com.example.app" }
 }


### PR DESCRIPTION
## Summary

Adds authenticated `app/deep-link` RPC execution to the public Portal for HTTP, local WebSocket, and reverse WebSocket clients.

Related to [DRO-2628](https://linear.app/droidrun/issue/DRO-2628/mobilerun-portal-deeplink-support).

Internal companion: [droidrun/mobilerun-portal-internal#79](https://github.com/droidrun/mobilerun-portal-internal/pull/79).

## Implementation

- requires a nonblank `deepLink`
- defaults `displayId` to `0` and blank `action` to `android.intent.action.VIEW`
- supports optional package pinning and the direct-RPC `packageName` compatibility alias
- preserves explicit blank `package` as unpinned resolution
- launches an implicit Android intent with `FLAG_ACTIVITY_NEW_TASK` and `ActivityOptions.setLaunchDisplayId`
- keeps Accessibility required and leaves the method unavailable in headless mode
- returns stable URI-free errors for invalid launches, missing handlers, and security failures
- redacts deep-link request and response payloads from reverse-connection logs
- documents the local and reverse RPC contract
- adds a debug-only package-specific fixture for deterministic device verification

No API schema, ContentProvider, environment variable, authentication callback, daemon, or version changes are included.

## Validation

Host (JDK 17):

- focused deep-link/gating/redaction tests: pass
- full debug JVM suite: 566 tests; only the documented pre-existing `SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates` failure
- `lintDebug`: pass
- `:app:assembleDebug`: pass
- `git diff --check`: pass

Device matrix:

- Android 16 / API 36: 7/7 instrumentation tests pass
- Android 15 / API 35 / 16 KB pages: 7/7 instrumentation tests pass
- on both versions: HTTP, authenticated local WebSocket, loopback reverse WebSocket, default/custom actions, pinned/unpinned resolution, alias/default handling, display 0, missing/invalid cases, fixture UI markers, and sanitized log redaction pass
- no Portal crashes or relevant accessibility/reverse-connection errors

Development cloud:

- the deployed Devices API `POST /devices/{deviceId}/apps/open-deep-link` route returned HTTP 204
- the public fixture opened successfully through the cloud connection and was independently verified via the device UI

## Product/observability checklist

- Devices API/OpenAPI ownership is already covered by [devices-api#654](https://github.com/droidrun/devices-api/pull/654)
- OTEL and PostHog were considered; no APK-side telemetry addition is needed for this execution-layer RPC
- no environment or marketing/communication change is required