### PR TITLE
[DRO-2646] Prevent keep-awake foreground-service crash

### DIFF
--- a/app/src/androidTest/java/com/mobilerun/portal/keepalive/KeepAliveServiceLifecycleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mobilerun/portal/keepalive/KeepAliveServiceLifecycleInstrumentedTest.kt
@@ -1,0 +1,106 @@
+package com.mobilerun.portal.keepalive
+
+import android.Manifest
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class KeepAliveServiceLifecycleInstrumentedTest {
+    @Test(timeout = 90_000L)
+    fun rapidEnableStatusDisableDoesNotCrashAndServiceRemainsReusable() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+        try {
+            KeepAliveController.disable(context)
+            awaitStatus(context, enabled = false, serviceActive = false)
+
+            repeat(50) {
+                KeepAliveController.enable(context)
+                assertTrue(KeepAliveController.getStatus(context).enabled)
+                KeepAliveController.disable(context)
+            }
+
+            awaitStatus(context, enabled = false, serviceActive = false)
+            watchDisabledState(context)
+            awaitNotification(context, present = false)
+
+            KeepAliveController.enable(context)
+            awaitStatus(context, enabled = true, serviceActive = true)
+            awaitNotification(context, present = true)
+
+            KeepAliveController.disable(context)
+            awaitStatus(context, enabled = false, serviceActive = false)
+            awaitNotification(context, present = false)
+        } finally {
+            KeepAliveController.disable(context)
+        }
+    }
+
+    private fun watchDisabledState(context: Context) {
+        val deadline = SystemClock.elapsedRealtime() + WATCHDOG_DURATION_MS
+        while (SystemClock.elapsedRealtime() < deadline) {
+            val status = KeepAliveController.getStatus(context)
+            assertEquals("keep-awake enabled state during watchdog", false, status.enabled)
+            assertEquals("keep-alive service state during watchdog", false, status.serviceActive)
+            SystemClock.sleep(WATCHDOG_POLL_INTERVAL_MS)
+        }
+    }
+
+    private fun awaitStatus(
+        context: Context,
+        enabled: Boolean,
+        serviceActive: Boolean,
+    ) {
+        val deadline = SystemClock.elapsedRealtime() + STATUS_TIMEOUT_MS
+        var status = KeepAliveController.getStatus(context)
+        while (
+            (status.enabled != enabled || status.serviceActive != serviceActive) &&
+            SystemClock.elapsedRealtime() < deadline
+        ) {
+            SystemClock.sleep(POLL_INTERVAL_MS)
+            status = KeepAliveController.getStatus(context)
+        }
+
+        assertEquals("keep-awake enabled state", enabled, status.enabled)
+        assertEquals("keep-alive service state", serviceActive, status.serviceActive)
+    }
+
+    private fun awaitNotification(context: Context, present: Boolean) {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val deadline = SystemClock.elapsedRealtime() + STATUS_TIMEOUT_MS
+        var notificationPresent =
+            notificationManager.activeNotifications.any { it.id == KEEP_ALIVE_NOTIFICATION_ID }
+        while (notificationPresent != present && SystemClock.elapsedRealtime() < deadline) {
+            SystemClock.sleep(POLL_INTERVAL_MS)
+            notificationPresent =
+                notificationManager.activeNotifications.any { it.id == KEEP_ALIVE_NOTIFICATION_ID }
+        }
+
+        assertEquals("keep-alive foreground notification", present, notificationPresent)
+    }
+
+    private companion object {
+        const val WATCHDOG_DURATION_MS = 15_000L
+        const val WATCHDOG_POLL_INTERVAL_MS = 100L
+        const val STATUS_TIMEOUT_MS = 5_000L
+        const val POLL_INTERVAL_MS = 25L
+        const val KEEP_ALIVE_NOTIFICATION_ID = 2004
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/keepalive/KeepAliveService.kt
+++ b/app/src/main/java/com/mobilerun/portal/keepalive/KeepAliveService.kt
@@ -37,6 +37,10 @@ class KeepAliveService : Service(), ConfigManager.ConfigChangeListener {
 
         fun isRunning(): Boolean = instance != null
 
+        fun requestStopIfRunning() {
+            instance?.requestStopAfterLatestStart()
+        }
+
         fun notifyRecoveryResult(
             context: Context,
             recoveryToken: Long,
@@ -91,29 +95,32 @@ class KeepAliveService : Service(), ConfigManager.ConfigChangeListener {
     private var receiverRegistered = false
     private var recoveryInFlight = false
     private var activeRecoveryToken: Long? = null
+    private var latestStartId = 0
 
     override fun onCreate() {
         super.onCreate()
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, createNotification())
         instance = this
         val configManager = ConfigManager.getInstance(this)
         configManager.addListener(this)
         restorePersistedRecoveryHandoffState(configManager)
-        createNotificationChannel()
         registerScreenStateReceiver()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        latestStartId = startId
         val configManager = ConfigManager.getInstance(applicationContext)
         if (intent?.action == ACTION_STOP) {
             KeepAliveController.disable(applicationContext)
+            requestStopAfterLatestStart()
             return START_NOT_STICKY
         }
         if (!configManager.keepScreenAwakeEnabled) {
-            stopSelf()
+            requestStopAfterLatestStart()
             return START_NOT_STICKY
         }
 
-        startForeground(NOTIFICATION_ID, createNotification())
         ensureSteadyWakeLock()
         schedulePoll()
         evaluateDeviceState(intent?.action ?: ACTION_RECONCILE)
@@ -134,6 +141,7 @@ class KeepAliveService : Service(), ConfigManager.ConfigChangeListener {
         releaseWakeLocks()
         recoveryInFlight = false
         activeRecoveryToken = null
+        latestStartId = 0
         instance = null
         super.onDestroy()
     }
@@ -152,7 +160,19 @@ class KeepAliveService : Service(), ConfigManager.ConfigChangeListener {
         if (!enabled) {
             recoveryInFlight = false
             activeRecoveryToken = null
-            stopSelf()
+            requestStopAfterLatestStart()
+        }
+    }
+
+    private fun requestStopAfterLatestStart() {
+        mainHandler.post {
+            if (ConfigManager.getInstance(applicationContext).keepScreenAwakeEnabled) {
+                return@post
+            }
+            val deliveredStartId = latestStartId
+            if (deliveredStartId != 0) {
+                stopSelfResult(deliveredStartId)
+            }
         }
     }
 
@@ -165,7 +185,7 @@ class KeepAliveService : Service(), ConfigManager.ConfigChangeListener {
         val appContext = applicationContext
         val status = KeepAliveController.getStatus(appContext)
         if (!status.enabled) {
-            stopSelf()
+            requestStopAfterLatestStart()
             return
         }
 

--- a/app/src/main/java/com/mobilerun/portal/keepalive/KeepAliveServiceRuntime.kt
+++ b/app/src/main/java/com/mobilerun/portal/keepalive/KeepAliveServiceRuntime.kt
@@ -32,8 +32,7 @@ object KeepAliveServiceRuntime {
         }
     }
 
-    fun stop(context: Context) {
-        val appContext = context.applicationContext
-        appContext.stopService(Intent(appContext, KeepAliveService::class.java))
+    fun stop(@Suppress("UNUSED_PARAMETER") context: Context) {
+        KeepAliveService.requestStopIfRunning()
     }
 }


### PR DESCRIPTION
## Summary

- promote `KeepAliveService` immediately in `onCreate()`, before publishing the live instance or registering listeners
- make shutdown service-owned and start-ID-aware so a rapid disable cannot cancel a newer foreground-service start
- add a mirrored 50-cycle instrumentation regression with a 15-second watchdog, final-state checks, sustained re-enable, and foreground-notification assertions

## Root cause

A valid rapid sequence—

```text
screen/keepAwake/set(enabled=true)
screen/keepAwake/status
screen/keepAwake/set(enabled=false)
```

—could stop a service created by `startForegroundService()` before it called `startForeground()`, producing `ForegroundServiceDidNotStartInTimeException` and killing Portal. There was a second ordering hazard when a live service received a newer queued start: a plain `stopSelf()` or external `stopService()` could consume that newer obligation.

The service now promotes first, records the latest delivered `startId`, posts stop decisions to its main thread, rechecks the persisted target state, and calls `stopSelfResult(latestStartId)`. A pending service creation is allowed to reach `onCreate()`, promote, and then safely self-stop if the saved state is disabled.

## Compatibility

- preserves `ACTION_STOP`, disabled-state shutdown, wake-lock recovery, controller behavior, and enabled `START_STICKY` semantics
- no RPC, response-schema, ContentProvider, daemon, permission, manifest, or version changes
- test notification assertions remain unconditional on Android 8 and are permission-aware on API 33+
- exact mirrored production logic with the internal companion: [mobilerun-portal-internal#80](https://github.com/droidrun/mobilerun-portal-internal/pull/80)

## Validation

### Host (OpenJDK 17.0.20)

- focused keep-awake/API/provider tests: **137 passed**
- full debug unit suite: **566 tests**, with only the documented pre-existing `SwitchTintResourceTest.trackTintSeparatesCheckedAndUncheckedStates` failure
- `lintDebug`: passed
- `assembleDebug` + instrumentation APK assembly: passed
- `git diff --check`: passed

### Android matrix

| Device | Instrumentation | Local transport stress | Headless | Reverse WS | Mobilerun UI + notification Stop |
|---|---:|---|---|---|---|
| Android 8 / API 26 | 8/8 | 25 sync + 25 pipelined; pass | n/a | pass | pass |
| Android 15 / API 35, 16 KB | 8/8 | 25 sync + 25 pipelined; pass | 10 + 10; pass | pass | pass |
| Android 16 / API 36 | 8/8 | 25 sync + 25 pipelined; pass | 10 + 10; pass | pass | pass |

Across all devices:

- 15-second watchdog completed with unchanged Portal PID
- original authenticated WebSocket stayed responsive and accessibility state remained available
- sustained enable produced `enabled=true/serviceActive=true`, service, notification ID 2004, and `keep_alive_steady` wake lock
- disable removed the service, notification, and wake lock
- HTTP authentication passed and keep-awake mutation retained its existing WebSocket-only rejection
- sanitized logcat contained no foreground-service timeout, missing-promotion, `RemoteServiceException`, crash, ANR, process restart, or accessibility failure

Cloud tasks and the unrelated insufficient-balance condition were intentionally excluded.

Internal companion: [mobilerun-portal-internal#80](https://github.com/droidrun/mobilerun-portal-internal/pull/80).

Related to [DRO-2646](https://linear.app/droidrun/issue/DRO-2646/prevent-keep-awake-foreground-service-crash-on-rapid-enabledisable).