### PR TITLE
[DRO-2700] Stop Portal retries after HTTP 402

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/PortalApplication.kt
+++ b/app/src/main/java/com/mobilerun/portal/PortalApplication.kt
@@ -4,9 +4,12 @@ import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import android.util.Log
+import com.mobilerun.portal.config.ConfigManager
 import com.mobilerun.portal.keepalive.KeepAliveController
+import com.mobilerun.portal.service.http402BlockedPresentationState
 import com.mobilerun.portal.state.AppForegroundTransitionTracker
 import com.mobilerun.portal.state.AppVisibilityTracker
+import com.mobilerun.portal.state.ConnectionStateManager
 
 class PortalApplication : Application() {
     private val foregroundTransitionTracker =
@@ -17,6 +20,12 @@ class PortalApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        val configManager = ConfigManager.getInstance(this)
+        val http402Snapshot = configManager.reverseJoinHttp402Snapshot()
+        http402BlockedPresentationState(
+            blocked = http402Snapshot.blocked,
+            explicitlyDisconnected = http402Snapshot.explicitlyDisconnected,
+        )?.let(ConnectionStateManager::setState)
         registerActivityLifecycleCallbacks(
             object : ActivityLifecycleCallbacks {
                 override fun onActivityCreated(

--- a/app/src/main/java/com/mobilerun/portal/config/ConfigManager.kt
+++ b/app/src/main/java/com/mobilerun/portal/config/ConfigManager.kt
@@ -12,6 +12,11 @@ import com.mobilerun.portal.taskprompt.PortalTaskSettings
 import com.mobilerun.portal.taskprompt.PortalTaskTracking
 import com.mobilerun.portal.taskprompt.TaskPromptSettingsConstraints
 
+internal data class ReverseJoinHttp402Snapshot(
+    val blocked: Boolean,
+    val explicitlyDisconnected: Boolean,
+)
+
 /**
  * Centralized configuration manager for Mobilerun Portal
  * Handles SharedPreferences operations and provides a clean API for configuration management
@@ -36,6 +41,10 @@ class ConfigManager private constructor(private val context: Context) {
         private const val KEY_REVERSE_CONNECTION_TOKEN = "reverse_connection_token"
         private const val KEY_REVERSE_CONNECTION_ENABLED = "reverse_connection_enabled"
         private const val KEY_REVERSE_CONNECTION_SERVICE_KEY = "reverse_connection_service_key"
+        private const val KEY_REVERSE_JOIN_BLOCKED_BY_HTTP_402 =
+            "reverse_join_blocked_by_http_402"
+        private const val KEY_REVERSE_JOIN_DISCONNECTED_WHILE_HTTP_402_BLOCKED =
+            "reverse_join_disconnected_while_http_402_blocked"
         private const val KEY_PRODUCTION_MODE = "production_mode"
         private const val KEY_DEV_MODE_ENABLED = "dev_mode_enabled"
         private const val KEY_INSTALL_AUTO_ACCEPT_ENABLED = "install_auto_accept_enabled"
@@ -110,6 +119,8 @@ class ConfigManager private constructor(private val context: Context) {
 
     private val devicePrefs: SharedPreferences =
         context.getSharedPreferences(DEVICE_PREFS_NAME, Context.MODE_PRIVATE)
+
+    private val reverseJoinHttp402Lock = Any()
 
     private val secretsPrefs: SharedPreferences =
         context.getSharedPreferences(SECRET_PREFS_NAME, Context.MODE_PRIVATE)
@@ -222,7 +233,16 @@ class ConfigManager private constructor(private val context: Context) {
             return if (stored.isNullOrBlank()) DEFAULT_REVERSE_CONNECTION_URL else stored
         }
         set(value) {
+            val currentEffectiveUrl = normalizeReverseConnectionUrlForStorage(
+                reverseConnectionUrlOrDefault,
+            )
+            val newEffectiveUrl = normalizeReverseConnectionUrlForStorage(
+                value.ifBlank { DEFAULT_REVERSE_CONNECTION_URL },
+            )
             sharedPrefs.edit { putString(KEY_REVERSE_CONNECTION_URL, value) }
+            if (newEffectiveUrl != currentEffectiveUrl) {
+                reverseJoinBlockedByHttp402 = false
+            }
         }
 
     val reverseConnectionUrlOrDefault: String
@@ -243,11 +263,16 @@ class ConfigManager private constructor(private val context: Context) {
             secretsPrefs.getString(KEY_REVERSE_CONNECTION_TOKEN, ""),
         ) ?: ""
         set(value) {
+            val normalizedValue = CloudTokenNormalizer.normalize(value).orEmpty()
+            val changed = normalizedValue != reverseConnectionToken
             secretsPrefs.edit {
                 putString(
                     KEY_REVERSE_CONNECTION_TOKEN,
-                    CloudTokenNormalizer.normalize(value).orEmpty(),
+                    normalizedValue,
                 )
+            }
+            if (changed) {
+                reverseJoinBlockedByHttp402 = false
             }
         }
 
@@ -255,7 +280,11 @@ class ConfigManager private constructor(private val context: Context) {
     var reverseConnectionServiceKey: String
         get() = secretsPrefs.getString(KEY_REVERSE_CONNECTION_SERVICE_KEY, "") ?: ""
         set(value) {
+            val changed = value != reverseConnectionServiceKey
             secretsPrefs.edit { putString(KEY_REVERSE_CONNECTION_SERVICE_KEY, value) }
+            if (changed) {
+                reverseJoinBlockedByHttp402 = false
+            }
         }
 
     var productionMode: Boolean
@@ -314,6 +343,58 @@ class ConfigManager private constructor(private val context: Context) {
         }
 
     var reverseConnectionEnabled: Boolean = false
+
+    /**
+     * Stored with the device identity so the block survives process restarts but is excluded from
+     * backup and device transfer. Writes are synchronous because reconnect callbacks can race the
+     * WebSocket close callback that records an HTTP 402.
+     */
+    var reverseJoinBlockedByHttp402: Boolean
+        get() = reverseJoinHttp402Snapshot().blocked
+        set(value) {
+            synchronized(reverseJoinHttp402Lock) {
+                val previous = readReverseJoinHttp402SnapshotLocked()
+                devicePrefs.edit(commit = true) {
+                    putBoolean(KEY_REVERSE_JOIN_BLOCKED_BY_HTTP_402, value)
+                    if (!value || !previous.blocked) {
+                        remove(KEY_REVERSE_JOIN_DISCONNECTED_WHILE_HTTP_402_BLOCKED)
+                    }
+                }
+            }
+        }
+
+    val reverseJoinDisconnectedWhileHttp402Blocked: Boolean
+        get() = reverseJoinHttp402Snapshot().explicitlyDisconnected
+
+    internal fun reverseJoinHttp402Snapshot(): ReverseJoinHttp402Snapshot {
+        return synchronized(reverseJoinHttp402Lock) {
+            readReverseJoinHttp402SnapshotLocked()
+        }
+    }
+
+    fun markReverseJoinExplicitlyDisconnected() {
+        synchronized(reverseJoinHttp402Lock) {
+            val snapshot = readReverseJoinHttp402SnapshotLocked()
+            devicePrefs.edit(commit = true) {
+                if (snapshot.blocked) {
+                    putBoolean(KEY_REVERSE_JOIN_DISCONNECTED_WHILE_HTTP_402_BLOCKED, true)
+                } else {
+                    remove(KEY_REVERSE_JOIN_DISCONNECTED_WHILE_HTTP_402_BLOCKED)
+                }
+            }
+        }
+    }
+
+    private fun readReverseJoinHttp402SnapshotLocked(): ReverseJoinHttp402Snapshot {
+        val blocked = devicePrefs.getBoolean(KEY_REVERSE_JOIN_BLOCKED_BY_HTTP_402, false)
+        return ReverseJoinHttp402Snapshot(
+            blocked = blocked,
+            explicitlyDisconnected = blocked && devicePrefs.getBoolean(
+                KEY_REVERSE_JOIN_DISCONNECTED_WHILE_HTTP_402_BLOCKED,
+                false,
+            ),
+        )
+    }
 
     var forceLoginOnNextConnect: Boolean
         get() = sharedPrefs.getBoolean("force_login_on_next_connect", false)

--- a/app/src/main/java/com/mobilerun/portal/service/MobilerunContentProvider.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/MobilerunContentProvider.kt
@@ -239,8 +239,10 @@ internal fun handleCloudConnectInsert(
         readProviderStringValue(contentValues, key, "MobilerunContentProvider")
     },
     beforeEnable: () -> Unit = {},
-    startReverseConnectionService: (Context, Intent) -> Unit = { context, intent ->
-        context.startForegroundService(intent)
+    startReverseConnectionService: (Context, String) -> Unit = { context, action ->
+        context.startForegroundService(
+            Intent(action, null, context, ReverseConnectionService::class.java),
+        )
     },
 ): ApiResponse {
     val appContext = providerContext?.applicationContext
@@ -265,13 +267,7 @@ internal fun handleCloudConnectInsert(
         configManager.forceLoginOnNextConnect = false
         beforeEnable()
         configManager.reverseConnectionEnabled = true
-        val serviceIntent = Intent(
-            ReverseConnectionService.ACTION_RECONNECT,
-            null,
-            appContext,
-            ReverseConnectionService::class.java,
-        )
-        startReverseConnectionService(appContext, serviceIntent)
+        startReverseConnectionService(appContext, ReverseConnectionService.ACTION_RECONNECT)
         ApiResponse.Success("Cloud connection requested")
     } catch (e: Exception) {
         ApiResponse.Error("Could not start cloud connection: ${e.message}")
@@ -283,8 +279,13 @@ internal fun buildCloudStatusResponse(
     connectionStateProvider: () -> ConnectionState = { ConnectionStateManager.getState() },
 ): ApiResponse {
     val activeTask = configManager.activePortalTask
+    val http402Snapshot = configManager.reverseJoinHttp402Snapshot()
+    val connectionState = http402BlockedPresentationState(
+        blocked = http402Snapshot.blocked,
+        explicitlyDisconnected = http402Snapshot.explicitlyDisconnected,
+    ) ?: connectionStateProvider()
     val json = JSONObject().apply {
-        put("connectionState", connectionStateProvider().name)
+        put("connectionState", connectionState.name)
         put("tokenPresent", configManager.reverseConnectionToken.trim().isNotEmpty())
         put("deviceId", configManager.deviceID)
         put("reverseConnectionUrl", configManager.reverseConnectionUrlOrDefault)
@@ -396,12 +397,15 @@ internal fun handleReverseConnectionConfigInsert(
     readStringValue: (ContentValues?, String) -> String? = { contentValues, key ->
         readProviderStringValue(contentValues, key, "MobilerunContentProvider")
     },
-    startReverseConnectionService: (Context, Intent) -> Unit = { context, intent ->
-        context.startForegroundService(intent)
+    startReverseConnectionService: (Context, String) -> Unit = { context, action ->
+        context.startForegroundService(
+            Intent(action, null, context, ReverseConnectionService::class.java),
+        )
     },
     stopReverseConnectionService: (Context, Intent) -> Unit = { context, intent ->
         context.stopService(intent)
     },
+    publishConnectionState: (ConnectionState) -> Unit = ConnectionStateManager::setState,
 ): ApiResponse {
     return try {
         val url = readStringValue(values, "url")
@@ -410,36 +414,53 @@ internal fun handleReverseConnectionConfigInsert(
         val enabled = values?.getAsBoolean("enabled")
 
         var message = "Updated reverse connection config:"
+        var connectionConfigChanged = false
 
         if (url != null) {
+            val effectiveUrl = url.ifBlank { configManager.defaultReverseConnectionUrl }
+            connectionConfigChanged =
+                connectionConfigChanged || effectiveUrl != configManager.reverseConnectionUrlOrDefault
             configManager.reverseConnectionUrl = url
             message += " url=$url"
         }
         if (token != null) {
+            val normalizedToken = CloudTokenNormalizer.normalize(token).orEmpty()
+            connectionConfigChanged =
+                connectionConfigChanged || normalizedToken != configManager.reverseConnectionToken
             configManager.reverseConnectionToken = token
             message += " token=***"
         }
         if (serviceKey != null) {
+            connectionConfigChanged =
+                connectionConfigChanged || serviceKey != configManager.reverseConnectionServiceKey
             configManager.reverseConnectionServiceKey = serviceKey
             message += " service_key=***"
         }
         if (enabled != null) {
             configManager.reverseConnectionEnabled = enabled
             message += " enabled=$enabled"
+        }
 
+        val shouldReconnect = enabled == true ||
+            (enabled == null && connectionConfigChanged && configManager.reverseConnectionEnabled)
+        if (shouldReconnect || enabled == false) {
             val appContext = providerContext?.applicationContext
                 ?: throw IllegalStateException("context unavailable")
-            if (enabled) {
-                val serviceIntent = Intent(
-                    ReverseConnectionService.ACTION_RECONNECT,
-                    null,
+            if (shouldReconnect) {
+                startReverseConnectionService(
                     appContext,
-                    ReverseConnectionService::class.java,
+                    ReverseConnectionService.ACTION_RECONNECT,
                 )
-                startReverseConnectionService(appContext, serviceIntent)
             } else {
                 val serviceIntent = Intent(appContext, ReverseConnectionService::class.java)
-                stopReverseConnectionService(appContext, serviceIntent)
+                performExplicitReverseConnectionDisconnect(
+                    markExplicitlyDisconnected =
+                        configManager::markReverseJoinExplicitlyDisconnected,
+                    publishDisconnected = publishConnectionState,
+                    dispatchDisconnect = {
+                        stopReverseConnectionService(appContext, serviceIntent)
+                    },
+                )
             }
         }
 

--- a/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicy.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicy.kt
@@ -1,0 +1,140 @@
+package com.mobilerun.portal.service
+
+import com.mobilerun.portal.config.ReverseJoinHttp402Snapshot
+import com.mobilerun.portal.state.ConnectionState
+
+internal sealed interface ReverseConnectionRetryDecision {
+    data object Retry : ReverseConnectionRetryDecision
+
+    data class Stop(
+        val state: ConnectionState,
+        val blockAutomaticRetries: Boolean = false,
+    ) : ReverseConnectionRetryDecision
+}
+
+internal sealed interface ReverseConnectionStartDecision {
+    data object Connect : ReverseConnectionStartDecision
+
+    data class RestoreHttp402Block(
+        val state: ConnectionState,
+    ) : ReverseConnectionStartDecision
+}
+
+internal fun http402BlockedPresentationState(
+    blocked: Boolean,
+    explicitlyDisconnected: Boolean,
+): ConnectionState? {
+    if (!blocked) return null
+    return if (explicitlyDisconnected) {
+        ConnectionState.DISCONNECTED
+    } else {
+        ConnectionState.LIMIT_EXCEEDED
+    }
+}
+
+internal fun performExplicitReverseConnectionDisconnect(
+    markExplicitlyDisconnected: () -> Unit,
+    publishDisconnected: (ConnectionState) -> Unit,
+    dispatchDisconnect: () -> Unit,
+) {
+    markExplicitlyDisconnected()
+    publishDisconnected(ConnectionState.DISCONNECTED)
+    dispatchDisconnect()
+}
+
+internal class ReverseConnectionRetryController(
+    private val readHttp402Snapshot: () -> ReverseJoinHttp402Snapshot,
+    private val setHttp402Blocked: (Boolean) -> Unit,
+    private val markExplicitlyDisconnected: () -> Unit = {},
+) {
+    fun onStart(explicitReconnect: Boolean): ReverseConnectionStartDecision {
+        if (explicitReconnect) {
+            setHttp402Blocked(false)
+            return ReverseConnectionStartDecision.Connect
+        }
+        val blockedState = blockedPresentationStateOrNull()
+        return blockedState?.let(ReverseConnectionStartDecision::RestoreHttp402Block)
+            ?: ReverseConnectionStartDecision.Connect
+    }
+
+    fun onConnected() {
+        setHttp402Blocked(false)
+    }
+
+    fun onExplicitDisconnect() {
+        if (readHttp402Snapshot().blocked) {
+            markExplicitlyDisconnected()
+        }
+    }
+
+    fun blockedPresentationStateOrNull(): ConnectionState? {
+        val snapshot = readHttp402Snapshot()
+        return http402BlockedPresentationState(
+            blocked = snapshot.blocked,
+            explicitlyDisconnected = snapshot.explicitlyDisconnected,
+        )
+    }
+
+    fun onClose(
+        reason: String?,
+        cancelPendingReconnects: () -> Unit,
+    ): ReverseConnectionRetryDecision {
+        val decision = ReverseConnectionRetryPolicy.decisionForClose(reason)
+        if (decision is ReverseConnectionRetryDecision.Stop) {
+            if (decision.blockAutomaticRetries) {
+                // Persist before cancellation so any concurrently delivered callback sees the block.
+                setHttp402Blocked(true)
+            }
+            cancelPendingReconnects()
+        }
+        return decision
+    }
+}
+
+internal object ReverseConnectionRetryPolicy {
+    private val javaWebSocketStatus = Regex(
+        pattern = "Invalid status code received:\\s*(\\d{3})(?:\\b|$)",
+        option = RegexOption.IGNORE_CASE,
+    )
+    private val legacyLeadingStatus = Regex("^\\s*(\\d{3})(?:\\b|$)")
+
+    fun decisionForClose(reason: String?): ReverseConnectionRetryDecision {
+        if (reason == null) return ReverseConnectionRetryDecision.Retry
+
+        return when (extractHttpStatus(reason)) {
+            400 -> stop(ConnectionState.BAD_REQUEST)
+            401 -> stop(ConnectionState.UNAUTHORIZED)
+            402 -> stop(ConnectionState.LIMIT_EXCEEDED, blockAutomaticRetries = true)
+            403 -> stop(ConnectionState.LIMIT_EXCEEDED)
+            null -> decisionForLegacyReason(reason)
+            else -> ReverseConnectionRetryDecision.Retry
+        }
+    }
+
+    private fun extractHttpStatus(reason: String): Int? {
+        return javaWebSocketStatus.find(reason)?.groupValues?.get(1)?.toIntOrNull()
+            ?: legacyLeadingStatus.find(reason)?.groupValues?.get(1)?.toIntOrNull()
+    }
+
+    private fun decisionForLegacyReason(reason: String): ReverseConnectionRetryDecision {
+        return when {
+            reason.contains("Unauthorized", ignoreCase = true) ->
+                stop(ConnectionState.UNAUTHORIZED)
+
+            reason.contains("Forbidden", ignoreCase = true) ->
+                stop(ConnectionState.LIMIT_EXCEEDED)
+
+            reason.contains("Bad Request", ignoreCase = true) ->
+                stop(ConnectionState.BAD_REQUEST)
+
+            else -> ReverseConnectionRetryDecision.Retry
+        }
+    }
+
+    private fun stop(
+        state: ConnectionState,
+        blockAutomaticRetries: Boolean = false,
+    ): ReverseConnectionRetryDecision.Stop {
+        return ReverseConnectionRetryDecision.Stop(state, blockAutomaticRetries)
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
@@ -60,20 +60,6 @@ class ReverseConnectionService : Service() {
 
         fun getInstance(): ReverseConnectionService? = instance
 
-        /**
-         * Returns true if the WS close reason indicates a terminal error
-         * where we should tear down media and NOT auto-reconnect.
-         */
-        internal fun isTerminalClose(reason: String?): Boolean {
-            if (reason == null) return false
-            return reason.contains("Unauthorized", ignoreCase = true) ||
-                    reason.contains("Forbidden", ignoreCase = true) ||
-                    reason.contains("Bad Request", ignoreCase = true) ||
-                    reason.startsWith("401") ||
-                    reason.startsWith("403") ||
-                    reason.startsWith("400")
-        }
-
         /** Returns true if reconnection attempts have exceeded the give-up timeout. */
         internal fun shouldGiveUpReconnecting(reconnectStartedAtMs: Long, nowMs: Long): Boolean {
             if (reconnectStartedAtMs <= 0L) return false
@@ -91,6 +77,7 @@ class ReverseConnectionService : Service() {
 
     private val binder = LocalBinder()
     private lateinit var configManager: ConfigManager
+    private lateinit var retryController: ReverseConnectionRetryController
     private val actionDispatcherCache =
         ServiceInstanceCache<MobilerunAccessibilityService, ActionDispatcher>()
     private var headlessActionDispatcher: ActionDispatcher? = null
@@ -120,6 +107,13 @@ class ReverseConnectionService : Service() {
         super.onCreate()
         instance = this
         configManager = ConfigManager.getInstance(this)
+        retryController = ReverseConnectionRetryController(
+            readHttp402Snapshot = configManager::reverseJoinHttp402Snapshot,
+            setHttp402Blocked = { blocked ->
+                configManager.reverseJoinBlockedByHttp402 = blocked
+            },
+            markExplicitlyDisconnected = configManager::markReverseJoinExplicitlyDisconnected,
+        )
         EventHub.init(configManager)
         reverseDeviceEventRelay = ReverseDeviceEventRelay(::currentReverseEventSender)
         reverseDeviceEventRelay.start()
@@ -139,13 +133,23 @@ class ReverseConnectionService : Service() {
         }
         Log.d(TAG, "onStartCommand: Ensuring foreground...")
         ensureForeground()
-        if (intent?.action == ACTION_RECONNECT) {
+        val explicitReconnect = intent?.action == ACTION_RECONNECT
+        if (explicitReconnect) {
             Log.i(TAG, "onStartCommand: Reconnect requested with latest cloud config")
             isServiceRunning.set(true)
-            isReconnecting.set(false)
-            webSocketGeneration.clearReconnect()
-            reconnectStartedAtMs = 0L
-            handler.removeCallbacksAndMessages(null)
+            cancelPendingReconnects()
+        }
+        when (val startDecision = retryController.onStart(explicitReconnect)) {
+            is ReverseConnectionStartDecision.RestoreHttp402Block -> {
+                Log.i(TAG, "onStartCommand: HTTP 402 block is active; skipping automatic connect")
+                isServiceRunning.set(true)
+                restoreHttp402BlockedState(startDecision.state)
+                return START_STICKY
+            }
+
+            ReverseConnectionStartDecision.Connect -> Unit
+        }
+        if (explicitReconnect) {
             connectToHost()
             return START_STICKY
         }
@@ -175,7 +179,10 @@ class ReverseConnectionService : Service() {
         disconnect()
         actionDispatcherCache.clear()
         headlessActionDispatcher = null
-        ConnectionStateManager.setState(ConnectionState.DISCONNECTED)
+        ConnectionStateManager.setState(
+            retryController.blockedPresentationStateOrNull()
+                ?: ConnectionState.DISCONNECTED,
+        )
         try {
             signalingExecutor.shutdownNow()
         } catch (_: Exception) {
@@ -270,6 +277,11 @@ class ReverseConnectionService : Service() {
             Log.w(TAG, "connectToHost: Service not running, aborting")
             return
         }
+        retryController.blockedPresentationStateOrNull()?.let { blockedState ->
+            Log.i(TAG, "connectToHost: HTTP 402 block is active; skipping automatic connect")
+            restoreHttp402BlockedState(blockedState)
+            return
+        }
 
         val hostUrl = configManager.reverseConnectionUrlOrDefault
         if (hostUrl.isBlank()) {
@@ -294,6 +306,7 @@ class ReverseConnectionService : Service() {
                         TAG,
                         "onOpen: Connected to Host: $hostUrl, status=${handshakedata?.httpStatus}, message=${handshakedata?.httpStatusMessage}"
                     )
+                    retryController.onConnected()
                     reconnectStartedAtMs = 0L
                     ConnectionStateManager.setState(ConnectionState.CONNECTED)
                     showReverseConnectionToastIfEnoughTimeIsPassed()
@@ -314,25 +327,24 @@ class ReverseConnectionService : Service() {
                     Log.w(TAG, "Disconnected from Host: code=$code reason=$reason remote=$remote")
                     logNetworkState("onClose")
 
-                    if (isTerminalClose(reason)) {
-                        // Cancel any reconnect scheduled by onError (which fires before onClose)
-                        isReconnecting.set(false)
-                        handler.removeCallbacksAndMessages(null)
-                        val r = reason
-                            ?: return // isTerminalClose(null) is false, so reason is non-null here
-                        val state = when {
-                            r.contains("401") || r.contains("Unauthorized") ->
-                                ConnectionState.UNAUTHORIZED
-
-                            r.contains("403") || r.contains("Forbidden") ->
-                                ConnectionState.LIMIT_EXCEEDED
-
-                            else -> ConnectionState.BAD_REQUEST
+                    when (val decision = retryController.onClose(reason, ::cancelPendingReconnects)) {
+                        is ReverseConnectionRetryDecision.Stop -> {
+                            val state = if (decision.blockAutomaticRetries) {
+                                retryController.blockedPresentationStateOrNull()
+                                    ?: decision.state
+                            } else {
+                                decision.state
+                            }
+                            Log.w(
+                                TAG,
+                                "onClose: Terminal error ($state), tearing down media",
+                            )
+                            ConnectionStateManager.setState(state)
+                            handleWsDisconnected()
+                            return
                         }
-                        Log.w(TAG, "onClose: Terminal error ($state), tearing down media")
-                        ConnectionStateManager.setState(state)
-                        handleWsDisconnected()
-                        return
+
+                        ReverseConnectionRetryDecision.Retry -> Unit
                     }
 
                     // Transient disconnect: preserve media pipeline, just reconnect WS
@@ -370,6 +382,11 @@ class ReverseConnectionService : Service() {
     private var reconnectStartedAtMs = 0L
 
     private fun scheduleReconnect(connectionGeneration: Long = webSocketGeneration.current()) {
+        retryController.blockedPresentationStateOrNull()?.let { blockedState ->
+            Log.i(TAG, "Ignoring reconnect request while HTTP 402 block is active")
+            restoreHttp402BlockedState(blockedState)
+            return
+        }
         if (!webSocketGeneration.isCurrent(connectionGeneration)) {
             Log.d(TAG, "Ignoring stale reconnect request for generation $connectionGeneration")
             return
@@ -396,6 +413,12 @@ class ReverseConnectionService : Service() {
         ConnectionStateManager.setState(ConnectionState.RECONNECTING)
         Log.d(TAG, "Scheduling reconnect in ${RECONNECT_DELAY_MS}ms")
         handler.postDelayed({
+            retryController.blockedPresentationStateOrNull()?.let { blockedState ->
+                Log.i(TAG, "Skipping delayed reconnect while HTTP 402 block is active")
+                clearQueuedReconnectIfOwnedBy(connectionGeneration)
+                ConnectionStateManager.setState(blockedState)
+                return@postDelayed
+            }
             if (!webSocketGeneration.isCurrent(connectionGeneration)) {
                 Log.d(TAG, "Ignoring stale delayed reconnect for generation $connectionGeneration")
                 clearQueuedReconnectIfOwnedBy(connectionGeneration)
@@ -425,6 +448,18 @@ class ReverseConnectionService : Service() {
         }
     }
 
+    private fun cancelPendingReconnects() {
+        isReconnecting.set(false)
+        webSocketGeneration.clearReconnect()
+        reconnectStartedAtMs = 0L
+        handler.removeCallbacksAndMessages(null)
+    }
+
+    private fun restoreHttp402BlockedState(state: ConnectionState) {
+        cancelPendingReconnects()
+        ConnectionStateManager.setState(state)
+    }
+
     private fun closeWebSocket(): Long {
         val connectionGeneration = webSocketGeneration.advance()
         try {
@@ -448,6 +483,7 @@ class ReverseConnectionService : Service() {
 
     private fun disconnectByUser() {
         configManager.reverseConnectionEnabled = false
+        retryController.onExplicitDisconnect()
         isServiceRunning.set(false)
         isReconnecting.set(false)
         webSocketGeneration.clearReconnect()

--- a/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/MainActivity.kt
@@ -2,6 +2,7 @@ package com.mobilerun.portal.ui
 
 import com.mobilerun.portal.config.ConfigManager
 import com.mobilerun.portal.service.MobilerunAccessibilityService
+import com.mobilerun.portal.service.performExplicitReverseConnectionDisconnect
 import com.mobilerun.portal.state.ConnectionState
 import com.mobilerun.portal.state.ConnectionStateManager
 import com.mobilerun.portal.service.ReverseConnectionService
@@ -1466,15 +1467,18 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
     }
 
     private fun disconnectService() {
-        ConfigManager.getInstance(this).reverseConnectionEnabled = false
+        val configManager = ConfigManager.getInstance(this)
+        configManager.reverseConnectionEnabled = false
 
         val serviceIntent =
             Intent(this, ReverseConnectionService::class.java).apply {
                 action = ReverseConnectionService.ACTION_DISCONNECT
             }
-        startService(serviceIntent)
-
-        ConnectionStateManager.setState(ConnectionState.DISCONNECTED)
+        performExplicitReverseConnectionDisconnect(
+            markExplicitlyDisconnected = configManager::markReverseJoinExplicitlyDisconnected,
+            publishDisconnected = ConnectionStateManager::setState,
+            dispatchDisconnect = { startService(serviceIntent) },
+        )
     }
 
     private fun showSignOutConfirmation() {
@@ -1521,6 +1525,7 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
         val configManager = ConfigManager.getInstance(this)
         if (forceFreshLogin) {
             configManager.reverseConnectionToken = ""
+            configManager.reverseJoinBlockedByHttp402 = false
             configManager.reverseConnectionEnabled = false
             configManager.forceLoginOnNextConnect = true
             refreshCreditsBalance(force = true)
@@ -1529,12 +1534,13 @@ class MainActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener {
     }
 
     private fun restartReverseConnectionService() {
-        val serviceIntent = Intent(this, ReverseConnectionService::class.java)
-        stopService(serviceIntent)
-
-        Handler(Looper.getMainLooper()).postDelayed({
-            startForegroundService(serviceIntent)
-        }, 150)
+        val serviceIntent = Intent(
+            ReverseConnectionService.ACTION_RECONNECT,
+            null,
+            this,
+            ReverseConnectionService::class.java,
+        )
+        startForegroundService(serviceIntent)
     }
 
     private fun applyConnectionDialogWidth(dialog: AlertDialog) {

--- a/app/src/main/java/com/mobilerun/portal/ui/settings/ReverseConnectionSettingsPolicy.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/settings/ReverseConnectionSettingsPolicy.kt
@@ -1,0 +1,16 @@
+package com.mobilerun.portal.ui.settings
+
+internal object ReverseConnectionSettingsPolicy {
+    fun shouldReconnectAfterInputPersistence(
+        enabled: Boolean,
+        currentEffectiveUrl: String,
+        currentToken: String,
+        candidateUrl: String,
+        candidateToken: String,
+        defaultUrl: String,
+    ): Boolean {
+        if (!enabled) return false
+        val candidateEffectiveUrl = candidateUrl.ifBlank { defaultUrl }
+        return candidateEffectiveUrl != currentEffectiveUrl || candidateToken != currentToken
+    }
+}

--- a/app/src/main/java/com/mobilerun/portal/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/com/mobilerun/portal/ui/settings/SettingsActivity.kt
@@ -25,6 +25,7 @@ import com.mobilerun.portal.events.model.EventType
 import com.mobilerun.portal.keepalive.KeepAliveController
 import com.mobilerun.portal.service.MobilerunNotificationListener
 import com.mobilerun.portal.service.ReverseConnectionService
+import com.mobilerun.portal.service.performExplicitReverseConnectionDisconnect
 import com.mobilerun.portal.state.ConnectionState
 import com.mobilerun.portal.state.ConnectionStateManager
 import com.mobilerun.portal.taskprompt.PortalBalanceRepository
@@ -235,19 +236,35 @@ class SettingsActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener
                 binding.inputReverseToken.error = null
                 configManager.reverseConnectionUrl = url
                 configManager.reverseConnectionToken = token
+                intent.action = ReverseConnectionService.ACTION_RECONNECT
                 startForegroundService(intent)
             } else {
                 intent.action = ReverseConnectionService.ACTION_DISCONNECT
-                startService(intent)
+                performExplicitReverseConnectionDisconnect(
+                    markExplicitlyDisconnected =
+                        configManager::markReverseJoinExplicitlyDisconnected,
+                    publishDisconnected = ConnectionStateManager::setState,
+                    dispatchDisconnect = { startService(intent) },
+                )
             }
             refreshCreditsBalance(force = true)
         }
 
         binding.inputReverseUrl.setOnEditorActionListener { v, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE || actionId == EditorInfo.IME_ACTION_NEXT) {
-                configManager.reverseConnectionUrl = v.text.toString().trim()
+                val url = v.text.toString().trim()
+                val shouldReconnect =
+                    ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                        enabled = configManager.reverseConnectionEnabled,
+                        currentEffectiveUrl = configManager.reverseConnectionUrlOrDefault,
+                        currentToken = configManager.reverseConnectionToken,
+                        candidateUrl = url,
+                        candidateToken = configManager.reverseConnectionToken,
+                        defaultUrl = configManager.defaultReverseConnectionUrl,
+                    )
+                configManager.reverseConnectionUrl = url
                 if (actionId == EditorInfo.IME_ACTION_DONE) binding.inputReverseUrl.clearFocus()
-                restartServiceIfEnabled()
+                if (shouldReconnect) restartServiceIfEnabled()
                 refreshCreditsBalance(force = true)
                 true
             } else {
@@ -259,9 +276,18 @@ class SettingsActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener
             if (actionId == EditorInfo.IME_ACTION_DONE) {
                 val token = sanitizeToken(v.text?.toString())
                 binding.inputReverseToken.error = null
+                val shouldReconnect =
+                    ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                        enabled = configManager.reverseConnectionEnabled,
+                        currentEffectiveUrl = configManager.reverseConnectionUrlOrDefault,
+                        currentToken = configManager.reverseConnectionToken,
+                        candidateUrl = configManager.reverseConnectionUrlOrDefault,
+                        candidateToken = token,
+                        defaultUrl = configManager.defaultReverseConnectionUrl,
+                    )
                 configManager.reverseConnectionToken = token
                 binding.inputReverseToken.clearFocus()
-                restartServiceIfEnabled()
+                if (shouldReconnect) restartServiceIfEnabled()
                 refreshCreditsBalance(force = true)
                 true
             } else {
@@ -614,10 +640,11 @@ class SettingsActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener
     private fun restartServiceIfEnabled() {
         if (configManager.reverseConnectionEnabled) {
             val intent = Intent(
+                ReverseConnectionService.ACTION_RECONNECT,
+                null,
                 this,
                 ReverseConnectionService::class.java,
             )
-            stopService(intent)
             startForegroundService(intent)
         }
     }
@@ -627,9 +654,20 @@ class SettingsActivity : AppCompatActivity(), ConfigManager.ConfigChangeListener
     }
 
     private fun persistReverseConnectionInputs() {
-        configManager.reverseConnectionUrl = binding.inputReverseUrl.text?.toString()?.trim() ?: ""
-        configManager.reverseConnectionToken =
-            sanitizeToken(binding.inputReverseToken.text?.toString())
+        val url = binding.inputReverseUrl.text?.toString()?.trim() ?: ""
+        val token = sanitizeToken(binding.inputReverseToken.text?.toString())
+        val shouldReconnect =
+            ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                enabled = configManager.reverseConnectionEnabled,
+                currentEffectiveUrl = configManager.reverseConnectionUrlOrDefault,
+                currentToken = configManager.reverseConnectionToken,
+                candidateUrl = url,
+                candidateToken = token,
+                defaultUrl = configManager.defaultReverseConnectionUrl,
+            )
+        configManager.reverseConnectionUrl = url
+        configManager.reverseConnectionToken = token
+        if (shouldReconnect) restartServiceIfEnabled()
     }
 
     private fun currentCreditsToken(): String {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,7 +230,7 @@
     <!-- Connection States -->
     <string name="connection_failed_title">Connection Failed</string>
     <string name="error_unauthorized">Unauthorized \u2014 check your API key</string>
-    <string name="error_limit_exceeded">Device limit exceeded</string>
+    <string name="error_limit_exceeded">Your plan or available device slots don’t allow this device to connect. Update the plan or free a slot, then retry.</string>
     <string name="error_bad_request_actionable">Saved Mobilerun credentials may belong to a different account. Sign in again or update the connection.</string>
     <string name="error_bad_request">Bad request \u2014 check token and headers</string>
     <string name="error_unknown">An unknown error occurred</string>

--- a/app/src/test/java/com/mobilerun/portal/config/ConfigManagerTaskPromptTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/config/ConfigManagerTaskPromptTest.kt
@@ -301,6 +301,105 @@ class ConfigManagerTaskPromptTest {
     }
 
     @Test
+    fun reverseJoinBlockedByHttp402_persistsInBackupExcludedDeviceStore() {
+        val configManager = ConfigManager.getInstance(context)
+
+        assertFalse(configManager.reverseJoinBlockedByHttp402)
+
+        configManager.reverseJoinBlockedByHttp402 = true
+        clearSingleton()
+
+        assertTrue(ConfigManager.getInstance(context).reverseJoinBlockedByHttp402)
+        assertEquals(true, deviceStore["reverse_join_blocked_by_http_402"])
+        assertFalse(sharedStore.containsKey("reverse_join_blocked_by_http_402"))
+        assertFalse(secretsStore.containsKey("reverse_join_blocked_by_http_402"))
+    }
+
+    @Test
+    fun explicitDisconnectPreservesHttp402BlockAndDisconnectedPresentationAcrossRestart() {
+        val configManager = ConfigManager.getInstance(context)
+        configManager.reverseJoinBlockedByHttp402 = true
+
+        configManager.markReverseJoinExplicitlyDisconnected()
+
+        assertEquals(
+            ReverseJoinHttp402Snapshot(
+                blocked = true,
+                explicitlyDisconnected = true,
+            ),
+            configManager.reverseJoinHttp402Snapshot(),
+        )
+        assertEquals(
+            true,
+            deviceStore["reverse_join_disconnected_while_http_402_blocked"],
+        )
+
+        clearSingleton()
+        val restored = ConfigManager.getInstance(context)
+
+        assertEquals(
+            ReverseJoinHttp402Snapshot(
+                blocked = true,
+                explicitlyDisconnected = true,
+            ),
+            restored.reverseJoinHttp402Snapshot(),
+        )
+
+        // A late duplicate close from the same blocked attempt must not undo an explicit disconnect.
+        restored.reverseJoinBlockedByHttp402 = true
+        assertEquals(
+            ReverseJoinHttp402Snapshot(
+                blocked = true,
+                explicitlyDisconnected = true,
+            ),
+            restored.reverseJoinHttp402Snapshot(),
+        )
+
+        // A future explicit reconnect clears both persisted values before its one-shot attempt.
+        restored.reverseJoinBlockedByHttp402 = false
+        assertEquals(
+            ReverseJoinHttp402Snapshot(
+                blocked = false,
+                explicitlyDisconnected = false,
+            ),
+            restored.reverseJoinHttp402Snapshot(),
+        )
+    }
+
+    @Test
+    fun unchangedConnectionConfigDoesNotClearHttp402Block() {
+        val configManager = ConfigManager.getInstance(context)
+        configManager.reverseConnectionToken = "token"
+        configManager.reverseConnectionServiceKey = "service-key"
+        configManager.reverseJoinBlockedByHttp402 = true
+
+        configManager.reverseConnectionUrl = configManager.defaultReverseConnectionUrl
+        configManager.reverseConnectionToken = " token "
+        configManager.reverseConnectionServiceKey = "service-key"
+
+        assertTrue(configManager.reverseJoinBlockedByHttp402)
+    }
+
+    @Test
+    fun changedEndpointOrCredentialsClearHttp402BlockWhileConnectionIsDisabled() {
+        val configManager = ConfigManager.getInstance(context)
+        assertFalse(configManager.reverseConnectionEnabled)
+
+        configManager.reverseJoinBlockedByHttp402 = true
+        configManager.reverseConnectionUrl =
+            "wss://example.test/v1/providers/personal/join"
+        assertFalse(configManager.reverseJoinBlockedByHttp402)
+
+        configManager.reverseJoinBlockedByHttp402 = true
+        configManager.reverseConnectionToken = "new-token"
+        assertFalse(configManager.reverseJoinBlockedByHttp402)
+
+        configManager.reverseJoinBlockedByHttp402 = true
+        configManager.reverseConnectionServiceKey = "new-service-key"
+        assertFalse(configManager.reverseJoinBlockedByHttp402)
+    }
+
+    @Test
     fun clearCloudCredentials_preservesLocalApiToken() {
         sharedStore["overlay_visible"] = false
         sharedStore["socket_server_enabled"] = true
@@ -309,6 +408,7 @@ class ConfigManagerTaskPromptTest {
         secretsStore["auth_token"] = "auth-123"
         secretsStore["reverse_connection_token"] = "reverse-123"
         secretsStore["reverse_connection_service_key"] = "service-123"
+        deviceStore["reverse_join_blocked_by_http_402"] = true
 
         ConfigManager.getInstance(context).clearCloudCredentials()
 
@@ -332,6 +432,7 @@ class ConfigManagerTaskPromptTest {
         sharedStore["reverse_connection_enabled"] = true
         sharedStore["production_mode"] = true
         deviceStore["device_id"] = "device-123"
+        deviceStore["reverse_join_blocked_by_http_402"] = true
         secretsStore["auth_token"] = "auth-123"
         secretsStore["reverse_connection_token"] = "reverse-123"
         secretsStore["reverse_connection_service_key"] = "service-123"
@@ -348,6 +449,7 @@ class ConfigManagerTaskPromptTest {
         assertFalse(configManager.websocketEnabled)
         assertEquals(8081, configManager.websocketPort)
         assertFalse(configManager.reverseConnectionEnabled)
+        assertFalse(configManager.reverseJoinBlockedByHttp402)
         assertFalse(configManager.productionMode)
     }
 

--- a/app/src/test/java/com/mobilerun/portal/service/MobilerunContentProviderTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/MobilerunContentProviderTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.util.Log
 import com.mobilerun.portal.api.ApiResponse
 import com.mobilerun.portal.config.ConfigManager
+import com.mobilerun.portal.config.ReverseJoinHttp402Snapshot
 import com.mobilerun.portal.keepalive.KeepAliveController
 import com.mobilerun.portal.keepalive.KeepAliveStartupException
 import com.mobilerun.portal.state.ConnectionState
@@ -439,6 +440,7 @@ class MobilerunContentProviderTest {
         val configManager = mockk<ConfigManager>(relaxed = true)
         val defaultUrl = "wss://api.mobilerun.ai/v1/providers/personal/join"
         val started = AtomicBoolean(false)
+        var startedAction: String? = null
 
         every { configManager.defaultReverseConnectionUrl } returns defaultUrl
 
@@ -452,13 +454,15 @@ class MobilerunContentProviderTest {
                     else -> null
                 }
             },
-            startReverseConnectionService = { _, _ ->
+            startReverseConnectionService = { _, action ->
                 started.set(true)
+                startedAction = action
             },
         )
 
         assertEquals(ApiResponse.Success("Cloud connection requested"), result)
         assertTrue(started.get())
+        assertEquals(ReverseConnectionService.ACTION_RECONNECT, startedAction)
         verifySequence {
             configManager.defaultReverseConnectionUrl
             configManager.reverseConnectionUrl = defaultUrl
@@ -571,6 +575,118 @@ class MobilerunContentProviderTest {
     }
 
     @Test
+    fun handleReverseConnectionConfigInsert_enableUsesExplicitReconnectAction() {
+        val context = mockk<Context>(relaxed = true)
+        val values = mockk<ContentValues>()
+        val configManager = mockk<ConfigManager>(relaxed = true)
+        var startedAction: String? = null
+
+        every { values.getAsBoolean("enabled") } returns true
+
+        val result = handleReverseConnectionConfigInsert(
+            providerContext = context,
+            configManager = configManager,
+            values = values,
+            readStringValue = { _, _ -> null },
+            startReverseConnectionService = { _, action -> startedAction = action },
+        )
+
+        assertEquals(
+            ApiResponse.Success("Updated reverse connection config: enabled=true"),
+            result,
+        )
+        assertEquals(ReverseConnectionService.ACTION_RECONNECT, startedAction)
+    }
+
+    @Test
+    fun handleReverseConnectionConfigInsert_changedConfigReconnectsWhenEnabled() {
+        val context = mockk<Context>(relaxed = true)
+        val values = mockk<ContentValues>()
+        val configManager = mockk<ConfigManager>(relaxed = true)
+        var startedAction: String? = null
+
+        every { values.getAsBoolean("enabled") } returns null
+        every { configManager.reverseConnectionUrlOrDefault } returns
+            "wss://old.example/v1/providers/personal/join"
+        every { configManager.reverseConnectionEnabled } returns true
+
+        val result = handleReverseConnectionConfigInsert(
+            providerContext = context,
+            configManager = configManager,
+            values = values,
+            readStringValue = { _, key ->
+                if (key == "url") "wss://new.example/v1/providers/personal/join" else null
+            },
+            startReverseConnectionService = { _, action -> startedAction = action },
+        )
+
+        assertTrue(result is ApiResponse.Success)
+        assertEquals(ReverseConnectionService.ACTION_RECONNECT, startedAction)
+    }
+
+    @Test
+    fun handleReverseConnectionConfigInsert_unchangedConfigDoesNotReconnect() {
+        val context = mockk<Context>(relaxed = true)
+        val values = mockk<ContentValues>()
+        val configManager = mockk<ConfigManager>(relaxed = true)
+        val defaultUrl = "wss://api.mobilerun.ai/v1/providers/personal/join"
+        var startCount = 0
+
+        every { values.getAsBoolean("enabled") } returns null
+        every { configManager.defaultReverseConnectionUrl } returns defaultUrl
+        every { configManager.reverseConnectionUrlOrDefault } returns defaultUrl
+        every { configManager.reverseConnectionToken } returns "token"
+        every { configManager.reverseConnectionEnabled } returns true
+
+        val result = handleReverseConnectionConfigInsert(
+            providerContext = context,
+            configManager = configManager,
+            values = values,
+            readStringValue = { _, key ->
+                when (key) {
+                    "url" -> ""
+                    "token" -> "token"
+                    else -> null
+                }
+            },
+            startReverseConnectionService = { _, _ -> startCount += 1 },
+        )
+
+        assertTrue(result is ApiResponse.Success)
+        assertEquals(0, startCount)
+    }
+
+    @Test
+    fun handleReverseConnectionConfigInsert_disableRetainsBlockAndPublishesDisconnected() {
+        val context = mockk<Context>(relaxed = true)
+        val values = mockk<ContentValues>()
+        val configManager = mockk<ConfigManager>(relaxed = true)
+        var publishedState: ConnectionState? = null
+        var stopCount = 0
+
+        every { values.getAsBoolean("enabled") } returns false
+        every { configManager.reverseJoinBlockedByHttp402 } returns true
+
+        val result = handleReverseConnectionConfigInsert(
+            providerContext = context,
+            configManager = configManager,
+            values = values,
+            readStringValue = { _, _ -> null },
+            stopReverseConnectionService = { _, _ -> stopCount += 1 },
+            publishConnectionState = { publishedState = it },
+        )
+
+        assertEquals(
+            ApiResponse.Success("Updated reverse connection config: enabled=false"),
+            result,
+        )
+        assertEquals(ConnectionState.DISCONNECTED, publishedState)
+        assertEquals(1, stopCount)
+        verify(exactly = 1) { configManager.markReverseJoinExplicitlyDisconnected() }
+        verify(exactly = 0) { configManager.reverseJoinBlockedByHttp402 = false }
+    }
+
+    @Test
     fun buildCloudStatusResponse_reportsStateAndRedactsToken() {
         val configManager = mockk<ConfigManager>()
         every { configManager.reverseConnectionToken } returns "super-secret"
@@ -578,6 +694,11 @@ class MobilerunContentProviderTest {
         every { configManager.reverseConnectionUrlOrDefault } returns
             "wss://api.mobilerun.ai/v1/providers/personal/join"
         every { configManager.activePortalTask } returns null
+        every { configManager.reverseJoinHttp402Snapshot() } returns
+            ReverseJoinHttp402Snapshot(
+                blocked = false,
+                explicitlyDisconnected = false,
+            )
 
         val result = buildCloudStatusResponse(
             configManager = configManager,
@@ -590,6 +711,55 @@ class MobilerunContentProviderTest {
         assertTrue(json.getBoolean("tokenPresent"))
         assertEquals("device-123", json.getString("deviceId"))
         assertFalse(json.toString().contains("super-secret"))
+    }
+
+    @Test
+    fun buildCloudStatusResponse_reportsPersistedHttp402BlockAsLimitExceeded() {
+        val configManager = mockk<ConfigManager>()
+        every { configManager.reverseConnectionToken } returns "super-secret"
+        every { configManager.deviceID } returns "device-123"
+        every { configManager.reverseConnectionUrlOrDefault } returns
+            "wss://api.mobilerun.ai/v1/providers/personal/join"
+        every { configManager.activePortalTask } returns null
+        every { configManager.reverseJoinHttp402Snapshot() } returns
+            ReverseJoinHttp402Snapshot(
+                blocked = true,
+                explicitlyDisconnected = false,
+            )
+
+        val result = buildCloudStatusResponse(
+            configManager = configManager,
+            connectionStateProvider = { ConnectionState.DISCONNECTED },
+        )
+
+        assertTrue(result is ApiResponse.RawObject)
+        val json = (result as ApiResponse.RawObject).json
+        assertEquals("LIMIT_EXCEEDED", json.getString("connectionState"))
+    }
+
+    @Test
+    fun buildCloudStatusResponse_reportsExplicitDisconnectWhileRetainingHttp402Block() {
+        val configManager = mockk<ConfigManager>()
+        every { configManager.reverseConnectionToken } returns "super-secret"
+        every { configManager.deviceID } returns "device-123"
+        every { configManager.reverseConnectionUrlOrDefault } returns
+            "wss://api.mobilerun.ai/v1/providers/personal/join"
+        every { configManager.activePortalTask } returns null
+        every { configManager.reverseJoinHttp402Snapshot() } returns
+            ReverseJoinHttp402Snapshot(
+                blocked = true,
+                explicitlyDisconnected = true,
+            )
+
+        val result = buildCloudStatusResponse(
+            configManager = configManager,
+            connectionStateProvider = { ConnectionState.LIMIT_EXCEEDED },
+        )
+
+        assertTrue(result is ApiResponse.RawObject)
+        val json = (result as ApiResponse.RawObject).json
+        assertEquals("DISCONNECTED", json.getString("connectionState"))
+        assertTrue(configManager.reverseJoinHttp402Snapshot().blocked)
     }
 
     @Test

--- a/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicyTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicyTest.kt
@@ -1,0 +1,241 @@
+package com.mobilerun.portal.service
+
+import com.mobilerun.portal.config.ReverseJoinHttp402Snapshot
+import com.mobilerun.portal.state.ConnectionState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReverseConnectionRetryPolicyTest {
+    @Test
+    fun javaWebSocketHttp402_stopsAndBlocksAutomaticRetries() {
+        val reason =
+            "Invalid status code received: 402 Status line: HTTP/1.1 402 Payment Required"
+
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(
+                state = ConnectionState.LIMIT_EXCEEDED,
+                blockAutomaticRetries = true,
+            ),
+            ReverseConnectionRetryPolicy.decisionForClose(reason),
+        )
+    }
+
+    @Test
+    fun legacyLeadingHttp402_stopsAndBlocksAutomaticRetries() {
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(
+                state = ConnectionState.LIMIT_EXCEEDED,
+                blockAutomaticRetries = true,
+            ),
+            ReverseConnectionRetryPolicy.decisionForClose("402 Payment Required"),
+        )
+    }
+
+    @Test
+    fun terminalHandshakeStatuses_preserveExistingStateMappings() {
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(ConnectionState.BAD_REQUEST),
+            ReverseConnectionRetryPolicy.decisionForClose(
+                "Invalid status code received: 400 Bad Request",
+            ),
+        )
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(ConnectionState.UNAUTHORIZED),
+            ReverseConnectionRetryPolicy.decisionForClose("401 Unauthorized"),
+        )
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(ConnectionState.LIMIT_EXCEEDED),
+            ReverseConnectionRetryPolicy.decisionForClose("403 Forbidden"),
+        )
+    }
+
+    @Test
+    fun transientAndUnknownFailures_remainRetryable() {
+        listOf(
+            "409 Conflict",
+            "429 Too Many Requests",
+            "Invalid status code received: 503 Service Unavailable",
+            "connection reset",
+            null,
+        ).forEach { reason ->
+            assertEquals(
+                ReverseConnectionRetryDecision.Retry,
+                ReverseConnectionRetryPolicy.decisionForClose(reason),
+            )
+        }
+    }
+
+    @Test
+    fun explicitReconnectAllowsOneAttemptAndRepeatedHttp402RestoresBlock() {
+        var blocked = true
+        val controller = ReverseConnectionRetryController(
+            readHttp402Snapshot = {
+                ReverseJoinHttp402Snapshot(blocked, explicitlyDisconnected = false)
+            },
+            setHttp402Blocked = { blocked = it },
+        )
+
+        assertEquals(
+            ReverseConnectionStartDecision.RestoreHttp402Block(
+                ConnectionState.LIMIT_EXCEEDED,
+            ),
+            controller.onStart(explicitReconnect = false),
+        )
+
+        assertEquals(
+            ReverseConnectionStartDecision.Connect,
+            controller.onStart(explicitReconnect = true),
+        )
+        assertFalse(blocked)
+
+        controller.onClose("402 Payment Required") {}
+
+        assertTrue(blocked)
+        assertEquals(
+            ReverseConnectionStartDecision.RestoreHttp402Block(
+                ConnectionState.LIMIT_EXCEEDED,
+            ),
+            controller.onStart(explicitReconnect = false),
+        )
+    }
+
+    @Test
+    fun http402PersistsBlockBeforeCancelingAlreadyQueuedRetry() {
+        var blocked = false
+        val transitionOrder = mutableListOf<String>()
+        val reconnectQueue = ReverseWebSocketGenerationGate().apply {
+            markReconnectScheduled(current())
+        }
+        val controller = ReverseConnectionRetryController(
+            readHttp402Snapshot = {
+                ReverseJoinHttp402Snapshot(blocked, explicitlyDisconnected = false)
+            },
+            setHttp402Blocked = {
+                blocked = it
+                transitionOrder += "persist"
+            },
+        )
+
+        val decision = controller.onClose(
+            "Invalid status code received: 402 Payment Required",
+        ) {
+            transitionOrder += "cancel"
+            reconnectQueue.clearReconnect()
+        }
+
+        assertEquals(
+            ReverseConnectionRetryDecision.Stop(
+                state = ConnectionState.LIMIT_EXCEEDED,
+                blockAutomaticRetries = true,
+            ),
+            decision,
+        )
+        assertEquals(listOf("persist", "cancel"), transitionOrder)
+        assertTrue(blocked)
+        assertNull(reconnectQueue.reconnectOwner())
+    }
+
+    @Test
+    fun successfulConnectionClearsPersistedHttp402Block() {
+        var blocked = true
+        val controller = ReverseConnectionRetryController(
+            readHttp402Snapshot = {
+                ReverseJoinHttp402Snapshot(blocked, explicitlyDisconnected = false)
+            },
+            setHttp402Blocked = { blocked = it },
+        )
+
+        controller.onConnected()
+
+        assertFalse(blocked)
+    }
+
+    @Test
+    fun explicitDisconnectRetainsBlockButPresentsDisconnectedUntilOneShotReconnect() {
+        var blocked = true
+        var explicitlyDisconnected = false
+        val controller = ReverseConnectionRetryController(
+            readHttp402Snapshot = {
+                ReverseJoinHttp402Snapshot(blocked, explicitlyDisconnected)
+            },
+            setHttp402Blocked = { value ->
+                val wasBlocked = blocked
+                blocked = value
+                if (!value || !wasBlocked) {
+                    explicitlyDisconnected = false
+                }
+            },
+            markExplicitlyDisconnected = { explicitlyDisconnected = true },
+        )
+
+        controller.onExplicitDisconnect()
+
+        assertTrue(blocked)
+        assertTrue(explicitlyDisconnected)
+        assertEquals(ConnectionState.DISCONNECTED, controller.blockedPresentationStateOrNull())
+        assertEquals(
+            ReverseConnectionStartDecision.RestoreHttp402Block(
+                ConnectionState.DISCONNECTED,
+            ),
+            controller.onStart(explicitReconnect = false),
+        )
+        assertTrue(blocked)
+        assertEquals(ConnectionState.DISCONNECTED, controller.blockedPresentationStateOrNull())
+
+        assertEquals(
+            ReverseConnectionStartDecision.Connect,
+            controller.onStart(explicitReconnect = true),
+        )
+        assertFalse(blocked)
+        assertFalse(explicitlyDisconnected)
+
+        controller.onClose("402 Payment Required") {}
+
+        assertTrue(blocked)
+        assertFalse(explicitlyDisconnected)
+        assertEquals(ConnectionState.LIMIT_EXCEEDED, controller.blockedPresentationStateOrNull())
+    }
+
+    @Test
+    fun explicitDisconnectPersistsAndPublishesBeforeAsyncServiceDispatch() {
+        val transitionOrder = mutableListOf<String>()
+
+        performExplicitReverseConnectionDisconnect(
+            markExplicitlyDisconnected = { transitionOrder += "persist" },
+            publishDisconnected = { state ->
+                assertEquals(ConnectionState.DISCONNECTED, state)
+                transitionOrder += "publish"
+            },
+            dispatchDisconnect = { transitionOrder += "dispatch" },
+        )
+
+        assertEquals(listOf("persist", "publish", "dispatch"), transitionOrder)
+    }
+
+    @Test
+    fun http402PresentationStateSupportsProcessAndStatusRestoration() {
+        assertNull(
+            http402BlockedPresentationState(
+                blocked = false,
+                explicitlyDisconnected = true,
+            ),
+        )
+        assertEquals(
+            ConnectionState.LIMIT_EXCEEDED,
+            http402BlockedPresentationState(
+                blocked = true,
+                explicitlyDisconnected = false,
+            ),
+        )
+        assertEquals(
+            ConnectionState.DISCONNECTED,
+            http402BlockedPresentationState(
+                blocked = true,
+                explicitlyDisconnected = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/com/mobilerun/portal/ui/settings/ReverseConnectionSettingsPolicyTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/ui/settings/ReverseConnectionSettingsPolicyTest.kt
@@ -1,0 +1,61 @@
+package com.mobilerun.portal.ui.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReverseConnectionSettingsPolicyTest {
+    private val defaultUrl = "wss://api.mobilerun.ai/v1/providers/personal/join"
+
+    @Test
+    fun unchangedPersistenceDoesNotReconnectOrLiftHttp402Block() {
+        assertFalse(
+            ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                enabled = true,
+                currentEffectiveUrl = defaultUrl,
+                currentToken = "token",
+                candidateUrl = defaultUrl,
+                candidateToken = "token",
+                defaultUrl = defaultUrl,
+            ),
+        )
+    }
+
+    @Test
+    fun blankAndDefaultUrlsAreTheSameEffectiveEndpoint() {
+        assertFalse(
+            ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                enabled = true,
+                currentEffectiveUrl = defaultUrl,
+                currentToken = "token",
+                candidateUrl = "",
+                candidateToken = "token",
+                defaultUrl = defaultUrl,
+            ),
+        )
+    }
+
+    @Test
+    fun changedCredentialsOrEndpointReconnectOnlyWhileEnabled() {
+        assertTrue(
+            ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                enabled = true,
+                currentEffectiveUrl = defaultUrl,
+                currentToken = "old-token",
+                candidateUrl = defaultUrl,
+                candidateToken = "new-token",
+                defaultUrl = defaultUrl,
+            ),
+        )
+        assertFalse(
+            ReverseConnectionSettingsPolicy.shouldReconnectAfterInputPersistence(
+                enabled = false,
+                currentEffectiveUrl = defaultUrl,
+                currentToken = "old-token",
+                candidateUrl = "wss://example.test/v1/providers/personal/join",
+                candidateToken = "new-token",
+                defaultUrl = defaultUrl,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Parse Java-WebSocket handshake rejection text and classify HTTP 402 as `LIMIT_EXCEEDED`.
- Persist a backup-excluded 402 latch so automatic joins stay blocked across queued callbacks, sticky service recreation, process/app relaunch, and Android lifecycle restoration.
- Keep Retry and other explicit connect actions as one-shot attempts; a repeated 402 immediately restores the block.
- Preserve the latch across Disconnect while atomically persisting a separate `DISCONNECTED` presentation state.
- Preserve 409, 429, 5xx, malformed, and network failures as retryable.
- Keep the public enum and `cloud/status` response shape unchanged, and update the limit guidance.

## Verification

- `./gradlew :app:testDebugUnitTest :app:lintDebug :app:assembleDebug --no-daemon --console=plain` — passed.
- Focused policy, lifecycle, persistence, Settings, disconnect-ordering, and provider tests — passed.
- `git diff --check` — passed.
- Android 16 emulator `Medium_Phone_API_36.1`:
  - Persistent 402: 1 handshake over more than 12 seconds.
  - One Retry: exactly 1 additional handshake, with no automatic follow-up over more than 12 seconds.
  - Force-stop/relaunch and sticky-service process kill/recreation: 0 additional handshakes; `cloud/status` restored `LIMIT_EXCEEDED`.
  - Explicit provider disconnect after 402 persisted `DISCONNECTED` across force-stop/relaunch with 0 additional handshakes; re-enable made exactly 1 attempt and a repeated 402 restored `LIMIT_EXCEEDED`.
  - Dismiss hid the error for the current session while relaunch restored the blocked guidance.
  - HTTP 503: repeated automatic retries remained active.
  - Valid WebSocket + Retry: reached `CONNECTED`.
  - Development-cloud smoke against `wss://dev-api.mobilerun.ai/v1/providers/personal/join`: reached `CONNECTED`.
- Refreshed GitHub PR Test Build and Android Build jobs passed.
- Test APK, local server, ADB mappings, and emulator were cleaned up afterward.

## Scope

Portal-only. No server, release, version, or compatibility changes.

- Linear: [DRO-2700](https://linear.app/droidrun/issue/DRO-2700)
- Companion internal Portal PR: [droidrun/mobilerun-portal-internal#81](https://github.com/droidrun/mobilerun-portal-internal/pull/81)