### PR TITLE
[DRO-2700] Clarify HTTP 402 persistence flag

### DIFF
--- a/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicy.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicy.kt
@@ -8,7 +8,7 @@ internal sealed interface ReverseConnectionRetryDecision {
 
     data class Stop(
         val state: ConnectionState,
-        val blockAutomaticRetries: Boolean = false,
+        val persistHttp402Block: Boolean = false,
     ) : ReverseConnectionRetryDecision
 }
 
@@ -81,7 +81,7 @@ internal class ReverseConnectionRetryController(
     ): ReverseConnectionRetryDecision {
         val decision = ReverseConnectionRetryPolicy.decisionForClose(reason)
         if (decision is ReverseConnectionRetryDecision.Stop) {
-            if (decision.blockAutomaticRetries) {
+            if (decision.persistHttp402Block) {
                 // Persist before cancellation so any concurrently delivered callback sees the block.
                 setHttp402Blocked(true)
             }
@@ -104,7 +104,7 @@ internal object ReverseConnectionRetryPolicy {
         return when (extractHttpStatus(reason)) {
             400 -> stop(ConnectionState.BAD_REQUEST)
             401 -> stop(ConnectionState.UNAUTHORIZED)
-            402 -> stop(ConnectionState.LIMIT_EXCEEDED, blockAutomaticRetries = true)
+            402 -> stop(ConnectionState.LIMIT_EXCEEDED, persistHttp402Block = true)
             403 -> stop(ConnectionState.LIMIT_EXCEEDED)
             null -> decisionForLegacyReason(reason)
             else -> ReverseConnectionRetryDecision.Retry
@@ -133,8 +133,8 @@ internal object ReverseConnectionRetryPolicy {
 
     private fun stop(
         state: ConnectionState,
-        blockAutomaticRetries: Boolean = false,
+        persistHttp402Block: Boolean = false,
     ): ReverseConnectionRetryDecision.Stop {
-        return ReverseConnectionRetryDecision.Stop(state, blockAutomaticRetries)
+        return ReverseConnectionRetryDecision.Stop(state, persistHttp402Block)
     }
 }

--- a/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
+++ b/app/src/main/java/com/mobilerun/portal/service/ReverseConnectionService.kt
@@ -329,7 +329,7 @@ class ReverseConnectionService : Service() {
 
                     when (val decision = retryController.onClose(reason, ::cancelPendingReconnects)) {
                         is ReverseConnectionRetryDecision.Stop -> {
-                            val state = if (decision.blockAutomaticRetries) {
+                            val state = if (decision.persistHttp402Block) {
                                 retryController.blockedPresentationStateOrNull()
                                     ?: decision.state
                             } else {

--- a/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicyTest.kt
+++ b/app/src/test/java/com/mobilerun/portal/service/ReverseConnectionRetryPolicyTest.kt
@@ -10,25 +10,25 @@ import org.junit.Test
 
 class ReverseConnectionRetryPolicyTest {
     @Test
-    fun javaWebSocketHttp402_stopsAndBlocksAutomaticRetries() {
+    fun javaWebSocketHttp402_stopsAndPersistsHttp402Block() {
         val reason =
             "Invalid status code received: 402 Status line: HTTP/1.1 402 Payment Required"
 
         assertEquals(
             ReverseConnectionRetryDecision.Stop(
                 state = ConnectionState.LIMIT_EXCEEDED,
-                blockAutomaticRetries = true,
+                persistHttp402Block = true,
             ),
             ReverseConnectionRetryPolicy.decisionForClose(reason),
         )
     }
 
     @Test
-    fun legacyLeadingHttp402_stopsAndBlocksAutomaticRetries() {
+    fun legacyLeadingHttp402_stopsAndPersistsHttp402Block() {
         assertEquals(
             ReverseConnectionRetryDecision.Stop(
                 state = ConnectionState.LIMIT_EXCEEDED,
-                blockAutomaticRetries = true,
+                persistHttp402Block = true,
             ),
             ReverseConnectionRetryPolicy.decisionForClose("402 Payment Required"),
         )
@@ -47,7 +47,10 @@ class ReverseConnectionRetryPolicyTest {
             ReverseConnectionRetryPolicy.decisionForClose("401 Unauthorized"),
         )
         assertEquals(
-            ReverseConnectionRetryDecision.Stop(ConnectionState.LIMIT_EXCEEDED),
+            ReverseConnectionRetryDecision.Stop(
+                state = ConnectionState.LIMIT_EXCEEDED,
+                persistHttp402Block = false,
+            ),
             ReverseConnectionRetryPolicy.decisionForClose("403 Forbidden"),
         )
     }
@@ -129,7 +132,7 @@ class ReverseConnectionRetryPolicyTest {
         assertEquals(
             ReverseConnectionRetryDecision.Stop(
                 state = ConnectionState.LIMIT_EXCEEDED,
-                blockAutomaticRetries = true,
+                persistHttp402Block = true,
             ),
             decision,
         )


### PR DESCRIPTION
## Summary

- Rename the internal retry-decision flag to `persistHttp402Block`.
- Clarify that HTTP 402 persists the restart-resistant latch while HTTP 403 remains terminal without persisting it.
- Keep runtime behavior, preference keys, provider responses, schemas, and public APIs unchanged.

## Verification

- `./gradlew :app:testDebugUnitTest --no-daemon --console=plain` — passed.
- `git diff --check` — passed.

## Related

- Follow-up to merged PR #162.
- Companion: [droidrun/mobilerun-portal-internal#82](https://github.com/droidrun/mobilerun-portal-internal/pull/82).